### PR TITLE
Default username / group and easier %ghost support.

### DIFF
--- a/src/main/java/org/freecompany/redline/ant/Ghost.java
+++ b/src/main/java/org/freecompany/redline/ant/Ghost.java
@@ -1,0 +1,46 @@
+package org.freecompany.redline.ant;
+
+/**
+ * Object describing a %ghost file
+ * to be added to the rpm without the
+ * file needing to exist beforehand.
+ */
+public class Ghost {
+
+    protected String path;
+    protected String username;
+    protected String group;
+    protected int filemode = -1;
+    protected int dirmode = -1;
+
+    public String getPath() {
+        return this.path;
+    }
+    public void setPath( String path) {
+        this.path = path;
+    }
+    public String getUsername() {
+        return this.username;
+    }
+    public void setUsername( String username) {
+        this.username = username;
+    }
+    public String getGroup() {
+        return this.group;
+    }
+    public void setGroup( String group) {
+        this.group = group;
+    }
+    public int getFilemode() {
+        return this.filemode;
+    }
+    public void setFilemode( int filemode) {
+        this.filemode = filemode;
+    }
+    public int getDirmode() {
+        return this.dirmode;
+    }
+    public void setDirmode( int dirmode) {
+        this.dirmode = dirmode;
+    }
+}

--- a/src/main/java/org/freecompany/redline/ant/RedlineTask.java
+++ b/src/main/java/org/freecompany/redline/ant/RedlineTask.java
@@ -54,6 +54,7 @@ public class RedlineTask extends Task {
 	protected Os os = LINUX;
 	protected File destination;
 	protected List< ArchiveFileSet> filesets = new ArrayList< ArchiveFileSet>();
+	protected List< Ghost> ghosts = new ArrayList< Ghost>();
 	protected List< Link> links = new ArrayList< Link>();
 	protected List< Depends> depends = new ArrayList< Depends>();
 
@@ -166,6 +167,9 @@ public class RedlineTask extends Task {
 					}
 				}
 			}
+			for ( Ghost ghost : ghosts) {
+				builder.addFile( ghost.getPath(), null, ghost.getFilemode(), ghost.getDirmode(), Directive.GHOST, ghost.getUsername(), ghost.getGroup());
+			}
 			for ( Link link : links) builder.addLink( link.getPath(), link.getTarget(), link.getPermissions());
 			for ( Depends dependency : depends) builder.addDependency( dependency.getName(), dependency.getComparison(), dependency.getVersion());
 
@@ -210,6 +214,7 @@ public class RedlineTask extends Task {
 	public void addZipfileset( ZipFileSet fileset) { filesets.add( fileset); }
 	public void addTarfileset( TarFileSet fileset) { filesets.add( fileset); }
     public void addRpmfileset( RpmFileSet fileset) { filesets.add( fileset); }
+	public void addGhost( Ghost ghost) { ghosts.add( ghost); }
 	public void addLink( Link link) { links.add( link); }
 	public void addDepends( Depends dependency) { depends.add( dependency); }
 	public void addTriggerPreIn( TriggerPreIn triggerPreIn) { triggersPreIn.add( triggerPreIn); }

--- a/src/main/java/org/freecompany/redline/payload/Contents.java
+++ b/src/main/java/org/freecompany/redline/payload/Contents.java
@@ -28,6 +28,9 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Logger.getLogger;
 import static org.freecompany.redline.Util.normalizePath;
 import static org.freecompany.redline.payload.CpioHeader.DEFAULT_DIRECTORY_PERMISSION;
+import static org.freecompany.redline.payload.CpioHeader.DEFAULT_FILE_PERMISSION;
+import static org.freecompany.redline.payload.CpioHeader.DEFAULT_USERNAME;
+import static org.freecompany.redline.payload.CpioHeader.DEFAULT_GROUP;
 import static org.freecompany.redline.payload.CpioHeader.DIR;
 import static org.freecompany.redline.payload.CpioHeader.FILE;
 import static org.freecompany.redline.payload.CpioHeader.SYMLINK;
@@ -175,11 +178,26 @@ public class Contents {
 		CpioHeader header = new CpioHeader( path);
 		header.setType( DIR);
 		header.setInode( inode++);
-		if (uname != null) header.setUname(uname);
-		if (gname != null) header.setGname(gname);
+		if ( null == uname) {
+			header.setUname(DEFAULT_USERNAME);
+		} else if (0 == uname.length()) {
+			header.setUname(DEFAULT_USERNAME);
+		} else {
+			header.setUname(uname);
+		}
+		if ( null == gname) {
+			header.setUname(DEFAULT_GROUP);
+		} else if (0 == gname.length()) {
+			header.setUname(DEFAULT_GROUP);
+		} else {
+			header.setUname(gname);
+		}
 		header.setMtime( System.currentTimeMillis());
-		if ( permissions != -1) header.setPermissions( permissions);
-		else header.setPermissions( DEFAULT_DIRECTORY_PERMISSION);
+		if ( -1 == permissions) {
+			header.setPermissions( DEFAULT_DIRECTORY_PERMISSION);
+		} else {
+			header.setPermissions( permissions);
+		}
 		headers.add( header);
 		sources.put( header, "");
 		if ( directive != null) header.setFlags( directive.flag());
@@ -259,12 +277,33 @@ public class Contents {
 		addParents( new File( path), dirmode, uname, gname);
 		files.add( path);
 		logger.log( FINE, "Adding file ''{0}''.", path);
-		CpioHeader header = new CpioHeader( path, source);
+		CpioHeader header;
+		if ( ( directive.flag() & Directive.RPMFILE_GHOST ) == Directive.RPMFILE_GHOST ) {
+			header = new CpioHeader( path);
+		} else {
+			header = new CpioHeader( path, source);
+		}
 		header.setType( FILE);
 		header.setInode( inode++);
-		if (uname != null) header.setUname(uname);
-		if (gname != null) header.setGname(gname);
-		if ( permissions != -1) header.setPermissions( permissions);
+		if ( null == uname) {
+			header.setUname(DEFAULT_USERNAME);
+		} else if (0 == uname.length()) {
+			header.setUname(DEFAULT_USERNAME);
+		} else {
+			header.setUname(uname);
+		}
+		if ( null == gname) {
+			header.setGname(DEFAULT_GROUP);
+		} else if (0 == gname.length()) {
+			header.setGname(DEFAULT_GROUP);
+		} else {
+			header.setGname(gname);
+		}
+		if ( -1 == permissions) {
+			header.setPermissions(DEFAULT_FILE_PERMISSION);
+		} else {
+			header.setPermissions( permissions);
+		}
 		headers.add( header);
 		sources.put( header, source);
 		

--- a/src/main/java/org/freecompany/redline/payload/CpioHeader.java
+++ b/src/main/java/org/freecompany/redline/payload/CpioHeader.java
@@ -24,6 +24,8 @@ public class CpioHeader {
 
 	public static final int DEFAULT_FILE_PERMISSION = 0644;
 	public static final int DEFAULT_DIRECTORY_PERMISSION = 0755;
+	public static final String DEFAULT_USERNAME = "root";
+	public static final String DEFAULT_GROUP = "root";
 
 	public static final int FIFO = 1;
 	public static final int CDEV = 2;


### PR DESCRIPTION
- Default username is now "root".
- Default group is now "root".
- Provide an easier way to designate %ghost files (similar to Link) so
  that these files are not required to exist at build time.
  
  Only the complete file path is required, all other attributes are
  optional and are subject to customary defaults if they are omitted
  (including the new defaults above).
  
  Example showing all attributes:
  
  &lt;ghost
    path="/opt/foo.txt"
    username="root"
    group="root"
    filemode="644"
    dirmode="755"
  />
