### PR TITLE
adding a rpmlib(feature) dependency did not set the proper flags

### DIFF
--- a/src/main/java/org/freecompany/redline/Builder.java
+++ b/src/main/java/org/freecompany/redline/Builder.java
@@ -117,7 +117,11 @@ public class Builder {
 	 * @param version the version identifier.
 	 */
 	public void addDependencyLess( final CharSequence name, final CharSequence version) {
-		addDependency( name, version, LESS | EQUAL);
+		int flag = LESS | EQUAL;
+		if (name.toString().startsWith("rpmlib(")){
+			flag = flag | RPMLIB; 
+		}
+		addDependency( name, version, flag);
 	}
 
 	/**

--- a/src/main/java/org/freecompany/redline/header/Flags.java
+++ b/src/main/java/org/freecompany/redline/header/Flags.java
@@ -17,4 +17,6 @@ public class Flags {
 	public static int SCRIPT_TRIGGERUN = 0x20000;
 	public static int SCRIPT_TRIGGERPOSTUN = 0x40000;
 	public static int SCRIPT_TRIGGERPREIN = 0x2000000;
+	public static int RPMLIB = (0x1000000 | PREREQ);
+
 }


### PR DESCRIPTION
The dependencies for rpmlib(feature) were being set as standard rpm dependencies.  For rpmlib bit 24 must be set in the REQUIREFLAGS header tag.  This is conforms to  with the rpm.org git repository. See the link below.
[gpm source patch](http://rpm.org/gitweb?p=rpm.git;a=blobdiff;f=build/reqprov.c;h=9c48b11c3eea39a2be7d68c1894802195ef2d598;hp=a57c6ae6d7f1df93b97d7486fdd2bcb19155b99c;hb=9fbaedd1ac655d978883d68a1f7d34df0d703363;hpb=b6cfb4399ca4c5f2335c9351a7599ccfdf28add6)
