### PR TITLE
Zypper error upon installing redline generated RPMS

### DIFF
--- a/src/main/java/org/freecompany/redline/Builder.java
+++ b/src/main/java/org/freecompany/redline/Builder.java
@@ -171,6 +171,7 @@ public class Builder {
 		format.getHeader().createEntry( NAME, name);
 		format.getHeader().createEntry( VERSION, version);
 		format.getHeader().createEntry( RELEASE, release);
+		format.getHeader().createEntry( PROVIDENAME, 8, new String[] { String.valueOf(name) });
 		format.getHeader().createEntry( PROVIDEVERSION, 8, new String[] { "0:" + version + "-" + release});
 		format.getHeader().createEntry( PROVIDEFLAGS, new int[] { 8});
 	}


### PR DESCRIPTION
Zypper is suse linux's package management tool. 

If you install a redline generate rpm and do not set the PROVIDENAME header. zypper will complain with the following excpeption :

Target initialization failed:
rpmdb2solv -r '/' -p '/etc/products.d' '/var/cache/zypp/solv/@System/solv'  > '/var/cache/zypp/solv/@System/solvkruxsf'
     bad dependency entries

The reason for this is, that zypper assumes that if there is a PROVIDEVERSION there should also be a PROVIDENAME header 

According to http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-package-structure.html#id623000

PROVIDEVERSION, PROVIDENAME and PROVIDEFLAGS should be used together
