### PR TITLE
Allows files to be added without parent directories

### DIFF
--- a/src/main/java/org/freecompany/redline/Builder.java
+++ b/src/main/java/org/freecompany/redline/Builder.java
@@ -718,6 +718,24 @@ public class Builder {
         contents.addFile( path, source, mode, directive, uname, gname, dirmode);
     }
 
+    /**
+     * Add the specified file to the repository payload in order.
+     * The required header entries will automatically be generated
+     * to record the directory names and file names, as well as their
+     * digests.
+     *
+     * @param path the absolute path at which this file will be installed.
+     * @param source the file content to include in this rpm.
+     * @param mode the mode of the target file in standard three octet notation, or -1 for default.
+     * @param dirmode the mode of the parent directories in standard three octet notation, or -1 for default.
+     * @param uname user owner for the given file, or null for default user.
+     * @param gname group owner for the given file, or null for default group.
+     * @param addParents whether to create parent directories for the file, defaults to true for other methods.
+     */
+    public void addFile( final String path, final File source, final int mode, final int dirmode, final Directive directive, final String uname, final String gname, final boolean addParents) throws NoSuchAlgorithmException, IOException {
+        contents.addFile( path, source, mode, directive, uname, gname, dirmode, addParents);
+    }
+
 	/**
 	 * Add the specified file to the repository payload in order.
 	 * The required header entries will automatically be generated

--- a/src/main/java/org/freecompany/redline/payload/Contents.java
+++ b/src/main/java/org/freecompany/redline/payload/Contents.java
@@ -272,9 +272,25 @@ public class Contents {
 	 * @param gname group owner for the given file
 	 */
 	public synchronized void addFile( final String path, final File source, final int permissions, final Directive directive, final String uname, final String gname, final int dirmode) throws FileNotFoundException {
+		addFile( path, source, permissions, directive, uname, gname, -1, true);
+	}
+
+	/**
+	 * Adds a file entry to the archive with the specified permissions.
+	 *
+	 * @param path the destination path for the installed file.
+	 * @param source the local file to be included in the package.
+	 * @param permissions the permissions flags, use -1 to leave as default.
+	 * @param directive directive indicating special handling for this file, use null to ignore.
+	 * @param uname user owner for the given file, use null for default user.
+	 * @param gname group owner for the given file, use null for default group.
+	 * @param dirmode permission flags for parent directories, use -1 to leave as default.
+	 * @param addParents whether to create parent directories for the file, defaults to true for other methods.
+	 */
+	public synchronized void addFile( final String path, final File source, final int permissions, final Directive directive, final String uname, final String gname, final int dirmode, final boolean addParents) throws FileNotFoundException {
 		if ( files.contains( path)) return;
 
-		addParents( new File( path), dirmode, uname, gname);
+		if ( addParents) addParents( new File( path), dirmode, uname, gname);
 		files.add( path);
 		logger.log( FINE, "Adding file ''{0}''.", path);
 		CpioHeader header;


### PR DESCRIPTION
Defaults to creating parent directories as now when adding files, but allows for the option to not have them be created.
