### PR TITLE
Remember header start and end position

### DIFF
--- a/src/main/java/org/freecompany/redline/Scanner.java
+++ b/src/main/java/org/freecompany/redline/Scanner.java
@@ -63,6 +63,7 @@ public class Scanner {
 	 */
 	public Format run( ReadableChannelWrapper in) throws Exception {
 		Format format = new Format();
+        Key< Integer> headerStartKey = in.start();
 		
 		Key< Integer> lead = in.start();
 		format.getLead().read( in);
@@ -73,10 +74,14 @@ public class Scanner {
 		int expected = ByteBuffer.wrap(( byte[]) format.getSignature().getEntry( SIGNATURES).getValues(), 8, 4).getInt() / -16;
 		System.out.println( "Signature ended at '" + in.finish( signature) + "' and contained '" + count + "' headers (expected '" + expected + "').");
 
-		Key< Integer> header = in.start();
+        Integer headerStartPos = in.finish(headerStartKey);
+        format.getHeader().setStartPos(headerStartPos);
+		Key< Integer> headerKey = in.start();
 		count = format.getHeader().read( in);
 		expected = ByteBuffer.wrap(( byte[]) format.getHeader().getEntry( HEADERIMMUTABLE).getValues(), 8, 4).getInt() / -16;
-		System.out.println( "Header ended at '" + in.finish( header) + " and contained '" + count + "' headers (expected '" + expected + "').");
+        Integer headerLength = in.finish(headerKey);
+        format.getHeader().setEndPos(headerStartPos + headerLength);
+        System.out.println( "Header ended at '" + headerLength + " and contained '" + count + "' headers (expected '" + expected + "').");
 
 		return format;
 	}

--- a/src/main/java/org/freecompany/redline/header/AbstractHeader.java
+++ b/src/main/java/org/freecompany/redline/header/AbstractHeader.java
@@ -34,6 +34,9 @@ public abstract class AbstractHeader {
 	protected final Map< Integer, Entry< ?>> entries = new TreeMap< Integer, Entry< ?>>();
 	protected final Map< Entry< ?>, Integer> pending = new LinkedHashMap< Entry< ?>, Integer>();
 
+    protected int startPos;
+    protected int endPos;
+
 	protected abstract boolean pad();
 
 	/**
@@ -284,7 +287,23 @@ public abstract class AbstractHeader {
 		throw new IllegalStateException( "Unknown entry type '" + type + "'.");
 	}
 
-	public interface Entry< T> {
+    public int getEndPos() {
+        return endPos;
+    }
+
+    public void setEndPos(int endPos) {
+        this.endPos = endPos;
+    }
+
+    public int getStartPos() {
+        return startPos;
+    }
+
+    public void setStartPos(int startPos) {
+        this.startPos = startPos;
+    }
+
+    public interface Entry< T> {
 		void setTag( int tag);
 		void setSize( int size);
 		void setCount( int count);

--- a/src/test/java/org/freecompany/redline/ScannerTest.java
+++ b/src/test/java/org/freecompany/redline/ScannerTest.java
@@ -1,7 +1,13 @@
 package org.freecompany.redline;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.nio.channels.Channels;
+
+import org.freecompany.redline.header.Format;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ScannerTest extends TestBase
 {
@@ -14,5 +20,16 @@ public class ScannerTest extends TestBase
     @Test
     public void scanSomeArchTest() throws Exception {
         Scanner.main ( new String[]{ getTestResourcesDirectory ( ) + File.separator + "rpm-3-1.0-1.somearch.rpm" } );
+    }
+
+    @Test
+    public void setHeaderStartAndEndPosition() throws Exception {
+        Format format = new Scanner().run(channelWrapper(getTestResourcesDirectory ( ) + File.separator + "rpm-1-1.0-1.noarch.rpm"));
+        assertEquals(280, format.getHeader().getStartPos());
+        assertEquals(4760, format.getHeader().getEndPos());
+    }
+
+    private ReadableChannelWrapper channelWrapper(String filename) throws Exception {
+        return new ReadableChannelWrapper( Channels.newChannel(new FileInputStream(filename)));
     }
 }


### PR DESCRIPTION
Hi Craig,

your library is great and widely used to build application rpms in our company. 
For generating yum metadata in Java we need the header start and end position which is needed for primary.xml.gz. Therefore it would be great to find this code in the next release.

Regards,
Sebastian
