### PR TITLE
Do not allow version or release to contain dashes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.12</version>
 				<configuration>
-					<test>*Test</test>
 					<excludes />
 				</configuration>
 			</plugin>

--- a/src/main/java/org/freecompany/redline/Builder.java
+++ b/src/main/java/org/freecompany/redline/Builder.java
@@ -160,13 +160,31 @@ public class Builder {
 	}
 
 	/**
+	 * @param variable the character sequence to check for dashes.
+	 * @param variableName the name to include in IllegalArgumentException
+	 * @throws IllegalArgumentException if passed in character sequence contains dashes.
+	 */
+	private void checkVariableContainsDashes(final CharSequence variable, final String variableName) {
+		for (int i = 0; i < variable.length(); i++) {
+			char currChar = variable.charAt(i);
+			if (currChar == '-') {
+				throw new IllegalArgumentException(variableName + " with value: '" + variable + "' contains dashes");
+			}
+		}
+	}
+
+	/**
 	 * <b>Required Field</b>. Sets the package information, such as the rpm name, the version, and the release number.
 	 * 
 	 * @param name the name of the RPM package.
 	 * @param version the version of the new package.
 	 * @param release the release number, specified after the version, of the new RPM.
+	 * @throws IllegalArgumentException if version or release contain
+	 *         dashes, as they are explicitly disallowed by RPM file format.
 	 */
 	public void setPackage( final CharSequence name, final CharSequence version, final CharSequence release) {
+		checkVariableContainsDashes(version, "version");
+		checkVariableContainsDashes(release, "release");
 		format.getLead().setName( name + "-" + version + "-" + release);
 		format.getHeader().createEntry( NAME, name);
 		format.getHeader().createEntry( VERSION, version);
@@ -319,7 +337,7 @@ public class Builder {
 	/**
 	 * Sets the group of contents to include in this RPM. Note that this method causes the existing
 	 * file set to be overwritten and therefore should be called before adding any other contents via
-	 * the {@link #addFile()} methods.
+	 * the <code>addFile()</code> methods.
 	 *
 	 * @param contents the set of contents to use in constructing this RPM.
 	 */

--- a/src/test/java/org/freecompany/redline/ant/RedlineTaskTest.java
+++ b/src/test/java/org/freecompany/redline/ant/RedlineTaskTest.java
@@ -17,6 +17,33 @@ import static org.junit.Assert.*;
 
 public class RedlineTaskTest extends TestCase {
 
+    public void testBadVersionWithDashes() throws Exception {
+	try {
+	    RedlineTask task = new RedlineTask();
+	    task.setName("nameRequired");
+	    task.setVersion("1.0-beta");
+	    task.setGroup("groupRequired");
+	    task.execute();
+	    fail();
+	} catch (IllegalArgumentException iae) {
+	    // Pass
+	}
+    }
+
+    public void testBadReleaseWithDashes() throws Exception {
+	try {
+	    RedlineTask task = new RedlineTask();
+	    task.setName("nameRequired");
+	    task.setVersion("versionRequired");
+	    task.setGroup("groupRequired");
+	    task.setRelease("2-3");
+	    task.execute();
+	    fail();
+	} catch (IllegalArgumentException iae) {
+	    // Pass
+	}
+    }
+
 	public void testRestrict() throws Exception {
 		Depends one = new Depends();
 		one.setName( "one");


### PR DESCRIPTION
The RPM file specification does not allow the version or release to
contain dashes, so throw IllegalArgumentException if they are set.

Also had to adjust pom to get tests to run.
