### PR TITLE
Fixed directory mode for automatically added parent directories

### DIFF
--- a/src/main/java/org/freecompany/redline/payload/Contents.java
+++ b/src/main/java/org/freecompany/redline/payload/Contents.java
@@ -273,7 +273,7 @@ public class Contents {
 	 * @param gname group owner for the given file
 	 */
 	public synchronized void addFile( final String path, final File source, final int permissions, final Directive directive, final String uname, final String gname, final int dirmode) throws FileNotFoundException {
-		addFile( path, source, permissions, directive, uname, gname, -1, true);
+		addFile( path, source, permissions, directive, uname, gname, dirmode, true);
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I realized the default dir rights I had set were not taken into account, so I traced the execution and stumbled upon this, which I assume is an error. Let me know if I'm mistaken !

Regards,
Eric
