### PR TITLE
Dependency to slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.5</version>
+			</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.5</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Project should only depends on slf4j-api in compile scope.

Slf4j has many implementations of "Binding"  and depending on one of them is not good practice.
Others project which want to use this project may want to use another binging.
