### PR TITLE
Moving "Skipping..." messages to debug output

### DIFF
--- a/src/main/java/org/redline_rpm/payload/CpioHeader.java
+++ b/src/main/java/org/redline_rpm/payload/CpioHeader.java
@@ -172,7 +172,7 @@ public class CpioHeader {
 
 	protected int skip( final ReadableByteChannel channel, final int total) throws IOException {
 		int skipped = Util.difference( total, 3);
-		LOGGER.info("Skipping '{}' bytes from stream at position '{}'.",skipped,total);
+		LOGGER.debug("Skipping '{}' bytes from stream at position '{}'.",skipped,total);
 		Util.fill( channel, skipped);
 		return skipped;
 	}
@@ -180,7 +180,7 @@ public class CpioHeader {
 	public int skip( final WritableByteChannel channel, int total) throws IOException {
 		int skipped = Util.difference( total, 3);
 		Util.empty( channel, ByteBuffer.allocate( skipped));
-        LOGGER.info("Skipping '{}' bytes from stream at position '{}'.",skipped,total);
+        	LOGGER.debug("Skipping '{}' bytes from stream at position '{}'.",skipped,total);
 		return skipped;
 	}
 


### PR DESCRIPTION
There is no need for there to be hundreds of these messages created when generating an rpm.  This is debugging info and should be logged at that level.
