### PR TITLE
added the ability to specify 'builtin' directories in rpm task

### DIFF
--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -108,6 +108,10 @@ public class Builder {
 		addDependencyLess( "rpmlib(CompressedFileNames)", "3.0.4-1");
 		addDependencyLess( "rpmlib(PayloadFilesHavePrefix)", "4.0-1");
 	}
+	
+	public void addBuiltinDirectory(String builtinDirectory) {
+		contents.addBuiltinDirectory(builtinDirectory);
+	}
 
 	public void addObsoletes(final String name, final int comparison, final String version) {
 		obsoletes.put(name, version);

--- a/src/main/java/org/redline_rpm/ant/BuiltIn.java
+++ b/src/main/java/org/redline_rpm/ant/BuiltIn.java
@@ -1,0 +1,23 @@
+package org.redline_rpm.ant;
+
+import org.apache.tools.ant.Project;
+
+public class BuiltIn {
+	
+	private final Project project;
+	
+	private String name;
+	
+	public BuiltIn( Project project) {
+		this.project = project;
+	}
+	
+	public void addText( String text) {
+		this.name = project.replaceProperties(text);
+	}
+	
+	public String getText() {
+		return name;
+	}
+
+}

--- a/src/main/java/org/redline_rpm/ant/RedlineTask.java
+++ b/src/main/java/org/redline_rpm/ant/RedlineTask.java
@@ -62,6 +62,8 @@ public class RedlineTask extends Task {
 	protected List< TriggerIn> triggersIn = new ArrayList< TriggerIn>();
 	protected List< TriggerUn> triggersUn = new ArrayList< TriggerUn>();
 	protected List< TriggerPostUn> triggersPostUn = new ArrayList< TriggerPostUn>();
+	
+	protected List< BuiltIn> builtIns = new ArrayList< BuiltIn>();
 
 	protected File preTransScript;
 	protected File preInstallScript;
@@ -108,6 +110,14 @@ public class RedlineTask extends Task {
         builder.setPrivateKeyPassphrase( privateKeyPassphrase);
 		if (sourcePackage != null) {
 			builder.addHeaderEntry(Header.HeaderTag.SOURCERPM, sourcePackage);
+		}
+		
+		// add built-ins
+		for ( BuiltIn builtIn : builtIns) {
+			String text = builtIn.getText();
+			if (text != null && !text.trim().equals("")) {
+				builder.addBuiltinDirectory( builtIn.getText());
+			}
 		}
 
 		try {
@@ -238,4 +248,5 @@ public class RedlineTask extends Task {
     public void setPrivateKeyRingFile( File privateKeyRingFile) { this.privateKeyRingFile = privateKeyRingFile; }
     public void setPrivateKeyId( String privateKeyId ) { this.privateKeyId = privateKeyId; }
     public void setPrivateKeyPassphrase( String privateKeyPassphrase ) { this.privateKeyPassphrase = privateKeyPassphrase; }
+    public void addBuiltin( BuiltIn builtIn) { builtIns.add(builtIn); }
 }

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -43,38 +43,9 @@ import static org.redline_rpm.payload.CpioHeader.SYMLINK;
  */
 public class Contents {
 
-	private static final Set< String> BUILTIN = new HashSet< String>();
+	private final Set< String> builtins = new HashSet< String>();
 	private static final Set< String> DOC_DIRS = new HashSet< String>();
 	static {
-		BUILTIN.add( "/");
-		BUILTIN.add( "/bin");
-		BUILTIN.add( "/dev");
-		BUILTIN.add( "/etc");
-		BUILTIN.add( "/etc/bash_completion.d");
-		BUILTIN.add( "/etc/cron.d");
-		BUILTIN.add( "/etc/cron.daily");
-		BUILTIN.add( "/etc/cron.hourly");
-		BUILTIN.add( "/etc/cron.monthly");
-		BUILTIN.add( "/etc/cron.weekly");
-		BUILTIN.add( "/etc/default");
-		BUILTIN.add( "/etc/init.d");
-		BUILTIN.add( "/etc/logrotate.d");
-		BUILTIN.add( "/lib");
-		BUILTIN.add( "/usr");
-		BUILTIN.add( "/usr/bin");
-		BUILTIN.add( "/usr/lib");
-		BUILTIN.add( "/usr/local");
-		BUILTIN.add( "/usr/local/bin");
-		BUILTIN.add( "/usr/local/lib");
-		BUILTIN.add( "/usr/sbin");
-		BUILTIN.add( "/usr/share");
-		BUILTIN.add( "/usr/share/applications");
-		BUILTIN.add( "/root");
-		BUILTIN.add( "/sbin");
-		BUILTIN.add( "/opt");
-		BUILTIN.add( "/tmp");
-		BUILTIN.add( "/var");
-		BUILTIN.add( "/var/log");
 		DOC_DIRS.add("/usr/doc");
 		DOC_DIRS.add("/usr/man");
 		DOC_DIRS.add("/usr/X11R6/man");
@@ -89,6 +60,39 @@ public class Contents {
 	protected final Set< CpioHeader> headers = new TreeSet< CpioHeader>( new HeaderComparator());
 	protected final Set< String> files = new HashSet< String>();
 	protected final Map< CpioHeader, Object> sources = new HashMap< CpioHeader, Object>();
+	
+	public Contents()
+	{
+		builtins.add( "/");
+		builtins.add( "/bin");
+		builtins.add( "/dev");
+		builtins.add( "/etc");
+		builtins.add( "/etc/bash_completion.d");
+		builtins.add( "/etc/cron.d");
+		builtins.add( "/etc/cron.daily");
+		builtins.add( "/etc/cron.hourly");
+		builtins.add( "/etc/cron.monthly");
+		builtins.add( "/etc/cron.weekly");
+		builtins.add( "/etc/default");
+		builtins.add( "/etc/init.d");
+		builtins.add( "/etc/logrotate.d");
+		builtins.add( "/lib");
+		builtins.add( "/usr");
+		builtins.add( "/usr/bin");
+		builtins.add( "/usr/lib");
+		builtins.add( "/usr/local");
+		builtins.add( "/usr/local/bin");
+		builtins.add( "/usr/local/lib");
+		builtins.add( "/usr/sbin");
+		builtins.add( "/usr/share");
+		builtins.add( "/usr/share/applications");
+		builtins.add( "/root");
+		builtins.add( "/sbin");
+		builtins.add( "/opt");
+		builtins.add( "/tmp");
+		builtins.add( "/var");
+		builtins.add( "/var/log");
+	}
 
 	/**
 	 * Adds a directory entry to the archive with the default permissions of 644.
@@ -387,8 +391,8 @@ public class Contents {
 	 *
 	 * @param directory the directory to add
 	 */
-	public synchronized static void addBuiltinDirectory( final String directory) {
-		BUILTIN.add(directory);
+	public synchronized void addBuiltinDirectory( final String directory) {
+		builtins.add(directory);
 	}
 
 	/**
@@ -715,12 +719,12 @@ public class Contents {
 	 * @param parents the list to add the parents to
 	 * @param file the file to search for parents of
 	 */
-	protected static void listParents( final List< String> parents, final File file) {
+	protected void listParents( final List< String> parents, final File file) {
 		final File parent = file.getParentFile();
 		if ( parent == null) return;
 		
 		final String path = normalizePath( parent.getPath());
-		if ( BUILTIN.contains( path)) return;
+		if ( builtins.contains( path)) return;
 
 		parents.add( path);
 		listParents( parents, parent);

--- a/src/test/java/org/redline_rpm/payload/ContentsTest.java
+++ b/src/test/java/org/redline_rpm/payload/ContentsTest.java
@@ -8,7 +8,7 @@ public class ContentsTest extends TestCase {
 
 	public void testListParents() throws Exception {
 		ArrayList< String> list = new ArrayList< String>();
-		Contents.listParents( list, new File( "/one/two/three/four"));
+		new Contents().listParents( list, new File( "/one/two/three/four"));
 
 		assertEquals( 3, list.size());
 		assertEquals( "/one/two/three", list.get( 0));
@@ -18,7 +18,7 @@ public class ContentsTest extends TestCase {
 
 	public void testListParentsBuiltin() throws Exception {
 		ArrayList< String> list = new ArrayList< String>();
-		Contents.listParents( list, new File( "/bin/one/two/three/four"));
+		new Contents().listParents( list, new File( "/bin/one/two/three/four"));
 
 		assertEquals( 3, list.size());
 		assertEquals( "/bin/one/two/three", list.get( 0));
@@ -28,8 +28,9 @@ public class ContentsTest extends TestCase {
 
 	public void testListParentsNewBuiltin() throws Exception {
 		ArrayList< String> list = new ArrayList< String>();
-		Contents.addBuiltinDirectory("/home");
-		Contents.listParents( list, new File( "/home/one/two/three/four"));
+		Contents contents = new Contents();
+		contents.addBuiltinDirectory("/home");
+		contents.listParents( list, new File( "/home/one/two/three/four"));
 
 		assertEquals( 3, list.size());
 		assertEquals( "/home/one/two/three", list.get( 0));


### PR DESCRIPTION
- previously, there was a static set of 'builtin' directory names
  (/etc, /opt/, ...) in Contents
- this didn't support cases where the RPM content was being deployed
  to an existing directory that didn't happen to be in the builtin list
  (the most obvious case being /etc/rc.d/init.d on RedHat/CentOS)
