### PR TITLE
Testing file modes are correct in Format.toString()

### DIFF
--- a/src/test/java/org/redline_rpm/ScannerTest.java
+++ b/src/test/java/org/redline_rpm/ScannerTest.java
@@ -6,8 +6,11 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.channels.Channels;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 public class ScannerTest extends TestBase
 {
@@ -32,6 +35,17 @@ public class ScannerTest extends TestBase
         Format format = new Scanner().run(channelWrapper(getTestResourcesDirectory ( ) + File.separator + "rpm-1-1.0-1.noarch.rpm"));
         assertEquals(280, format.getHeader().getStartPos());
         assertEquals(4760, format.getHeader().getEndPos());
+    }
+    @Test
+    public void fileModesHeaderIsCorrect() throws Exception {
+        Format format = new Scanner().run(channelWrapper(getTestResourcesDirectory ( ) + File.separator + "rpm-1-1.0-1.noarch.rpm"));
+        String rpmDescription = format.toString();
+        Matcher matcher = Pattern.compile(".*filemodes\\[[^\\]]*\\]\\n[^0-9-]*([^\\n]*).*", Pattern.DOTALL).matcher(rpmDescription);
+        matcher.matches();
+        String [] fileModesFromString = matcher.group(1).split(", ");
+        //String [] actual = {"-32348", "-24065", "16877", "-32275", "-32275", "-32275", "-32275", "-24083", "-32275", "16877", "-32348", "-32348", "16877", "-32348", "-24065,"};
+        String [] expectedFileModes = {"33188", "41471", "16877", "33261", "33261", "33261", "33261", "41453", "33261", "16877", "33188", "33188", "16877", "33188", "41471"};
+        assertArrayEquals(expectedFileModes, fileModesFromString);
     }
 
     private ReadableChannelWrapper channelWrapper(String filename) throws Exception {


### PR DESCRIPTION
This PR is a change to an existing test to check that the file modes are reported correctly in the Format.toString() method. This test currently fails… I’ve put the actual result in a comment for clarity—it looks like the bytes for each file mode might be being read incorrectly. This relates to issue #55.

I’d love to make the change but I’ve struggled to work out where the problem is—my guess is that the bytes for the mode are not actually stored as ByteBuffer.toShort() is expecting.
