### PR TITLE
#58 Add support for files and folders in /var/lib that have owner/group attributes set

### DIFF
--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -74,6 +74,7 @@ public class Contents {
 		BUILTIN.add( "/opt");
 		BUILTIN.add( "/tmp");
 		BUILTIN.add( "/var");
+		BUILTIN.add( "/var/lib");
 		BUILTIN.add( "/var/log");
 		DOC_DIRS.add("/usr/doc");
 		DOC_DIRS.add("/usr/man");


### PR DESCRIPTION
This fixes the issue in rpm packages (at least when created by redline ant task) that contains files or folder in /var/lib with owner/group other than root.

Wihtout this fix, rpm file installation on RHEL/CentOS system produces error: "file /var/lib from install of <name>-<version>.<arch> conflicts with file from package filesystem-<version>.<arch>".

For example: file /var/lib from install of test-0:1.1-1.noarch conflicts with file from package filesystem-3.2-18.el7.x86_64.
