### PR TITLE
Added ability to specify dirmode when adding a file

### DIFF
--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -290,7 +290,7 @@ public class Contents {
 	 * @throws java.io.FileNotFoundException file wasn't found
 	 */
 	public synchronized void addFile( final String path, final File source, final int permissions, final Directive directive, final String uname, final String gname, final int dirmode) throws FileNotFoundException {
-		addFile( path, source, permissions, directive, uname, gname, -1, true);
+		addFile( path, source, permissions, directive, uname, gname, dirmode, true);
 	}
 
 	/**

--- a/src/test/java/org/redline_rpm/payload/ContentsTest.java
+++ b/src/test/java/org/redline_rpm/payload/ContentsTest.java
@@ -1,14 +1,21 @@
 package org.redline_rpm.payload;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
 import junit.framework.TestCase;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class ContentsTest extends TestCase {
 
 	public void testListParents() throws Exception {
 		ArrayList< String> list = new ArrayList< String>();
-		new Contents().listParents( list, new File( "/one/two/three/four"));
+		new Contents().listParents(list, new File("/one/two/three/four"));
 
 		assertEquals( 3, list.size());
 		assertEquals( "/one/two/three", list.get( 0));
@@ -18,7 +25,7 @@ public class ContentsTest extends TestCase {
 
 	public void testListParentsBuiltin() throws Exception {
 		ArrayList< String> list = new ArrayList< String>();
-		new Contents().listParents( list, new File( "/bin/one/two/three/four"));
+		new Contents().listParents(list, new File("/bin/one/two/three/four"));
 
 		assertEquals( 3, list.size());
 		assertEquals( "/bin/one/two/three", list.get( 0));
@@ -48,4 +55,16 @@ public class ContentsTest extends TestCase {
 		assertEquals( "/home/one/two", list.get( 1));
 		assertEquals( "/home/one", list.get( 2));
 	}
+
+    public void testAddFileSetsDirModeOnHeader() throws FileNotFoundException {
+        Contents contents = new Contents();
+        contents.addFile("/test/file.txt", new File("/test/source"), 0777, null, "testuser", "testgroup", 0111);
+        Iterable<CpioHeader> headers = contents.headers();
+        Map<String, Integer> filemodes = new HashMap<String, Integer>();
+        for (CpioHeader header : headers) {
+            filemodes.put(header.getName(), header.getPermissions());
+        }
+        assertThat(filemodes.get("/test"), is(73));
+        assertThat(filemodes.get("/test/file.txt"), is(511));
+    }
 }


### PR DESCRIPTION
The dirmode was not being passed to the addFile method, rather the default value of -1 was meaning it was not possible to set permissions on the directory of a file. Created a test for this functionality and implemented the fix.
