### PR TITLE
Add BUILTIN directories: /srv, /var/cache, /var/spool

### DIFF
--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -72,10 +72,13 @@ public class Contents {
 		BUILTIN.add( "/root");
 		BUILTIN.add( "/sbin");
 		BUILTIN.add( "/opt");
+		BUILTIN.add( "/srv");
 		BUILTIN.add( "/tmp");
 		BUILTIN.add( "/var");
+		BUILTIN.add( "/var/cache");
 		BUILTIN.add( "/var/lib");
 		BUILTIN.add( "/var/log");
+		BUILTIN.add( "/var/spool");
 		DOC_DIRS.add("/usr/doc");
 		DOC_DIRS.add("/usr/man");
 		DOC_DIRS.add("/usr/X11R6/man");


### PR DESCRIPTION
Add new BUILTIN directories: /srv, /var/cache, /var/spool
This fixes similar issue as my previous pull request that added /var/lib to the BUILTIN directory listing.
