### PR TITLE
Add /usr/lib64 to the BUILTIN directory list.

### DIFF
--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -63,6 +63,7 @@ public class Contents {
 		BUILTIN.add( "/usr");
 		BUILTIN.add( "/usr/bin");
 		BUILTIN.add( "/usr/lib");
+		BUILTIN.add( "/usr/lib64");
 		BUILTIN.add( "/usr/local");
 		BUILTIN.add( "/usr/local/bin");
 		BUILTIN.add( "/usr/local/lib");


### PR DESCRIPTION
Add /usr/lib64 to the BUILTIN directory list as most libraries are installed there on modern distributions.
