### PR TITLE
Ghost and EmptyDir filemodes and dirmodes were not interpreted correctly and permissions are set incoreectly

### DIFF
--- a/src/main/java/org/redline_rpm/ant/EmptyDir.java
+++ b/src/main/java/org/redline_rpm/ant/EmptyDir.java
@@ -1,5 +1,6 @@
 package org.redline_rpm.ant;
 
+import org.apache.tools.zip.UnixStat;
 /**
  * Object describing an ampty dir
  * to be added to the rpm without the
@@ -35,12 +36,12 @@ public class EmptyDir {
         return this.filemode;
     }
     public void setFilemode( String filemode) {
-        this.filemode = Integer.parseInt(filemode, 8);
+        this.filemode = UnixStat.FILE_FLAG | Integer.parseInt(filemode, 8);
     }
     public int getDirmode() {
         return this.dirmode;
     }
     public void setDirmode( String dirmode) {
-        this.dirmode = Integer.parseInt(dirmode, 8);
+        this.dirmode = UnixStat.DIR_FLAG | Integer.parseInt(dirmode, 8);
     }
 }

--- a/src/main/java/org/redline_rpm/ant/EmptyDir.java
+++ b/src/main/java/org/redline_rpm/ant/EmptyDir.java
@@ -34,13 +34,13 @@ public class EmptyDir {
     public int getFilemode() {
         return this.filemode;
     }
-    public void setFilemode( int filemode) {
-        this.filemode = filemode;
+    public void setFilemode( String filemode) {
+        this.filemode = Integer.parseInt(filemode, 8);
     }
     public int getDirmode() {
         return this.dirmode;
     }
-    public void setDirmode( int dirmode) {
-        this.dirmode = dirmode;
+    public void setDirmode( String dirmode) {
+        this.dirmode = Integer.parseInt(dirmode, 8);
     }
 }

--- a/src/main/java/org/redline_rpm/ant/Ghost.java
+++ b/src/main/java/org/redline_rpm/ant/Ghost.java
@@ -34,13 +34,13 @@ public class Ghost {
     public int getFilemode() {
         return this.filemode;
     }
-    public void setFilemode( int filemode) {
-        this.filemode = filemode;
+    public void setFilemode( String filemode) {
+        this.filemode = Integer.parseInt(filemode, 8);
     }
     public int getDirmode() {
         return this.dirmode;
     }
-    public void setDirmode( int dirmode) {
-        this.dirmode = dirmode;
+    public void setDirmode( String dirmode) {
+        this.dirmode = Integer.parseInt(dirmode, 8);
     }
 }

--- a/src/main/java/org/redline_rpm/ant/Ghost.java
+++ b/src/main/java/org/redline_rpm/ant/Ghost.java
@@ -1,5 +1,7 @@
 package org.redline_rpm.ant;
 
+import org.apache.tools.zip.UnixStat;
+
 /**
  * Object describing a %ghost file
  * to be added to the rpm without the
@@ -35,12 +37,12 @@ public class Ghost {
         return this.filemode;
     }
     public void setFilemode( String filemode) {
-        this.filemode = Integer.parseInt(filemode, 8);
+        this.filemode = UnixStat.FILE_FLAG | Integer.parseInt(filemode, 8);
     }
     public int getDirmode() {
         return this.dirmode;
     }
     public void setDirmode( String dirmode) {
-        this.dirmode = Integer.parseInt(dirmode, 8);
+        this.dirmode = UnixStat.DIR_FLAG | Integer.parseInt(dirmode, 8);
     }
 }


### PR DESCRIPTION
when the dirmode and filemode are parsed by the FileSet; 
see org.apache.tools.ant.types.ArchiveFileSet.setDirMode(String octalString) 
see org.apache.tools.ant.types.ArchiveFileSet.setFileMode(String octalString) 

the following operation occurs;
filemode:  UnixStat.FILE_FLAG | Integer.parseInt(filemode, 8);
dirmode: UnixStat.DIR_FLAG | Integer.parseInt(dirmode, 8);

ie they are taking a Bitwise inclusive OR on the parsed string argument ( as a signed integer in the 8th radix) 

