### PR TITLE
Make RPM task not fail when the signature cannot be read

### DIFF
--- a/src/main/java/org/redline_rpm/SignatureGenerator.java
+++ b/src/main/java/org/redline_rpm/SignatureGenerator.java
@@ -10,7 +10,6 @@ import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.bouncycastle.openpgp.operator.bc.BcPBESecretKeyDecryptorBuilder;
 import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
 import org.redline_rpm.header.Signature;
-import org.redline_rpm.payload.Contents;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -38,7 +37,7 @@ public class SignatureGenerator {
     protected final PGPPrivateKey privateKey;
     protected Key< byte[]> headerOnlyKey = null;
     protected Key< byte[]> headerAndPayloadKey = null;
-    private Logger logger = getLogger( Contents.class.getName());
+    private Logger logger = getLogger( SignatureGenerator.class.getName());
 
     public SignatureGenerator( PGPPrivateKey privateKey ) {
         this.privateKey = privateKey;

--- a/src/main/java/org/redline_rpm/SignatureGenerator.java
+++ b/src/main/java/org/redline_rpm/SignatureGenerator.java
@@ -50,7 +50,7 @@ public class SignatureGenerator {
             PGPSecretKey secretKey = findMatchingSecretKey( keyRings, privateKeyId );
             PGPPrivateKey key = null;
             try { key = extractPrivateKey( secretKey, privateKeyPassphrase ); }catch( IllegalArgumentException e){
-                logger.warning("Private Key could not be extracted and therefore a signature wil not be generated! "+e.getLocalizedMessage());
+                logger.warning("Private Key could not be extracted and therefore a signature will not be generated! "+e.getLocalizedMessage());
             }
             privateKey=key; 
             this.enabled = key!=null?true:false;


### PR DESCRIPTION
Instead of falling miserably when the signature cannot be generated, catch the exception, print a warning message and skip the RPM signing. 

The scenario I am trying to solve is that an ant task has the private key file and passphrase defined. The passphrase is set by a property which by default is set to empty. Trusted computers pass in the passphrase by overriding the property that defines it whereas untrusted do not. Expected result is that both computers can create RPMs successfully, trusted ones created signed RPMs, untrusted ones create unsigned RPMs