### PR TITLE
Symlink size must be set properly in rpm header.

### DIFF
--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -488,7 +488,6 @@ public class Contents {
 			for ( Object object : sources.values()) {
 				if ( object instanceof File) total += (( File) object).length();
 				else if ( object instanceof URL) total += (( URL) object).openConnection().getContentLength();
-				else if ( object instanceof String) total += (( String) object).length();
 			}
 		} catch ( IOException e) {
 			throw new RuntimeException( e);

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -556,7 +556,7 @@ public class Contents {
 				if ( object instanceof File) array[ x] = ( int) (( File) object).length();
 				else if ( object instanceof URL) array[ x] = (( URL) object).openConnection().getContentLength();
 				else if ( header.getType() == DIR) array[ x] = 4096;
-				else if ( object instanceof String) array[ x] = (( String) object).length();
+				else if ( header.getType() == SYMLINK) array[ x] = (( String) object).length();
 				++x;
 			}
 		} catch ( IOException e) {

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -488,6 +488,7 @@ public class Contents {
 			for ( Object object : sources.values()) {
 				if ( object instanceof File) total += (( File) object).length();
 				else if ( object instanceof URL) total += (( URL) object).openConnection().getContentLength();
+				else if ( object instanceof String) total += (( String) object).length();
 			}
 		} catch ( IOException e) {
 			throw new RuntimeException( e);
@@ -556,6 +557,7 @@ public class Contents {
 				if ( object instanceof File) array[ x] = ( int) (( File) object).length();
 				else if ( object instanceof URL) array[ x] = (( URL) object).openConnection().getContentLength();
 				else if ( header.getType() == DIR) array[ x] = 4096;
+				else if ( object instanceof String) array[ x] = (( String) object).length();
 				++x;
 			}
 		} catch ( IOException e) {


### PR DESCRIPTION
The size for a symlink was previously set to zero in the rpm header. This was not a problem on older versions of rpm, but triggers an error on rpm 4.12.0.1 on Fedora 21.

This is a one line change that adds the length of the string in getSizes(). The instanceof String check happens after the check for a directory, so it will only execute for symlinks (no other type of entry is added to sources map with a String value). The first commit made a similar change in getTotalSize(), but after comparing to an rpmbuild built rpm, it appears that they do not include the size of symlinks in the total size in the header.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=1224555