### PR TITLE
Shading Bouncy Castle classes to prevent collision with Gradle API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,35 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>shaded-jar</shadedClassifierName>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.redline_rpm.Scanner</mainClass>
+                        </transformer>
+                    </transformers>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.bouncycastle</pattern>
+                            <shadedPattern>org.redline_rpm.bouncycastle</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
I've been working on a patch for the os-package Gradle plugin (https://github.com/nebula-plugins/gradle-ospackage-plugin) to support signing RPM/DEB packages. Luckily for me, both jDeb and Redline RPM already support signing packages, and those libraries are already being used by os-package. Unluckily for me, making use of the Gradle API for plugins causes some odd issues with dependencies; notably, even though Redline RPM has a dependency on Bouncy Castle 1.50, I'm seeing the Bouncy Castle 1.46 jar on the classpath which directly causes a MethodNotFound exception due to a changed contract between those versions. More information on Gradle's weirdness can be found on this blog post: http://jdpgrailsdev.github.io/blog/2014/04/15/gradle_api_dependencies.html .

This PR addresses the root issue for me by shading the Bouncy Castle classes in the Redline RPM jar.