### PR TITLE
Test cases for file ownership.

### DIFF
--- a/src/test/java/org/redline_rpm/BuilderTest.java
+++ b/src/test/java/org/redline_rpm/BuilderTest.java
@@ -3,9 +3,12 @@ package org.redline_rpm;
 import org.junit.Test;
 import org.redline_rpm.Scanner;
 import org.redline_rpm.header.Format;
+import org.redline_rpm.header.Header;
+import org.redline_rpm.payload.Directive;
 
 import java.io.File;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.redline_rpm.ScannerTest.channelWrapper;
 import static org.redline_rpm.header.Architecture.NOARCH;
@@ -27,6 +30,30 @@ public class BuilderTest extends TestBase {
         Format format = new Scanner().run(channelWrapper("target" + File.separator + "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxa-1.0-1.noarch.rpm"));
 
 		assertEquals("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", format.getLead().getName());
+    }
+    
+    @Test
+    public void testFiles() throws Exception {
+        Builder builder = new Builder();
+        builder.setPackage("filestest", "1.0", "1");
+        builder.setBuildHost( "localhost" );
+        builder.setLicense( "GPL" );
+        builder.setPlatform( NOARCH, LINUX );
+        builder.setType( BINARY );
+        builder.addFile( "/etc", new File("src/test/resources/prein.sh"), 0755, 0755,
+                new Directive(Directive.RPMFILE_CONFIG | Directive.RPMFILE_DOC | Directive.RPMFILE_NOREPLACE),
+                "jabberwocky", "vorpal");
+
+        builder.build( new File( getTargetDir()));
+
+        Format format = new Scanner().run(channelWrapper("target" + File.separator + "filestest-1.0-1.noarch.rpm"));
+
+        assertArrayEquals(new String[] { "jabberwocky" },
+                (String[])format.getHeader().getEntry(Header.HeaderTag.FILEUSERNAME).getValues());
+        assertArrayEquals(new String[] { "vorpal" },
+                (String[])format.getHeader().getEntry(Header.HeaderTag.FILEGROUPNAME).getValues());
+        assertArrayEquals(new int[] { Directive.RPMFILE_CONFIG | Directive.RPMFILE_DOC | Directive.RPMFILE_NOREPLACE },
+                (int[])format.getHeader().getEntry(Header.HeaderTag.FILEFLAGS).getValues());
     }
 
     @Test

--- a/src/test/java/org/redline_rpm/ant/RedlineTaskTest.java
+++ b/src/test/java/org/redline_rpm/ant/RedlineTaskTest.java
@@ -174,15 +174,6 @@ public class RedlineTaskTest extends TestBase {
 		task.setPreUninstallScript(new File("src/test/resources/preun.sh"));
 		task.setPostUninstallScript(new File("src/test/resources/postun.sh"));
 
-		RpmFileSet fs = new RpmFileSet();
-		fs.setPrefix("/etc");
-		fs.setFile(new File("src/test/resources/prein.sh"));
-		fs.setConfig(true);
-		fs.setNoReplace(true);
-		fs.setDoc(true);
-
-		task.addRpmfileset(fs);
-
 		task.execute();
 
 		Format format = getFormat( filename );
@@ -200,6 +191,36 @@ public class RedlineTaskTest extends TestBase {
 		assertHeaderEquals("/bin/sh", format, Header.HeaderTag.POSTINPROG);
 		assertHeaderEquals("/bin/sh", format, Header.HeaderTag.PREUNPROG);
 		assertHeaderEquals("/bin/sh", format, Header.HeaderTag.POSTUNPROG);
+	}
+
+	@Test
+	public void testFiles() throws Exception {
+
+		File dir = ensureTargetDir();
+
+		File filename = new File(dir, "rpmtest-1.0-1.noarch.rpm");
+
+		RedlineTask task = createBasicTask( dir );
+
+		RpmFileSet fs = new RpmFileSet();
+		fs.setPrefix("/etc");
+		fs.setFile(new File("src/test/resources/prein.sh"));
+		fs.setConfig(true);
+		fs.setNoReplace(true);
+		fs.setDoc(true);
+		fs.setUserName("jabberwocky");
+		fs.setGroup("vorpal");
+
+		task.addRpmfileset(fs);
+
+		task.execute();
+
+		Format format = getFormat( filename );
+
+		assertArrayEquals(new String[] { "jabberwocky" },
+				(String[])format.getHeader().getEntry(Header.HeaderTag.FILEUSERNAME).getValues());
+		assertArrayEquals(new String[] { "vorpal" },
+				(String[])format.getHeader().getEntry(Header.HeaderTag.FILEGROUPNAME).getValues());
 
 		int expectedFlags = Directive.RPMFILE_CONFIG | Directive.RPMFILE_DOC
 				| Directive.RPMFILE_NOREPLACE;


### PR DESCRIPTION
Test cases for both the Ant and Builder interface covering file
ownership.  The tests currently pass.  This may help in diagnosing
craigwblake/redline#81 and craigwblake/redline#44