### PR TITLE
Only add prefixes if list is not empty

### DIFF
--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -451,7 +451,7 @@ public class Builder {
 	 * @param prefixes Path prefixes which may be relocated
 	 */
 	public void setPrefixes( final String... prefixes) {
-		if ( prefixes != null) format.getHeader().createEntry( PREFIXES, prefixes);
+		if ( prefixes != null && 0 < prefixes.length) format.getHeader().createEntry( PREFIXES, prefixes);
 	}
 
     /**


### PR DESCRIPTION
Fixes an issue for rpm version 4.11 (Relates to Issue #61)