### PR TITLE
Fix version and add `/var/run` to BUILTIN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.redline-rpm</groupId>
 	<artifactId>redline</artifactId>
-	<version>1.2.2-SNAPSHOT</version>
+	<version>1.2.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Redline</name>
 	<description>Redline is a pure Java library for manipulating RPM Package Manager packages.</description>

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -79,6 +79,7 @@ public class Contents {
 		BUILTIN.add( "/var/cache");
 		BUILTIN.add( "/var/lib");
 		BUILTIN.add( "/var/log");
+		BUILTIN.add( "/var/run");
 		BUILTIN.add( "/var/spool");
 		DOC_DIRS.add("/usr/doc");
 		DOC_DIRS.add("/usr/man");


### PR DESCRIPTION
You appear to have left the version as the older and released one (1.2.2). 
Also, adding `/var/run` to the BUILTIN section prevents collision (esp with Amazon linux, at the moment).  
I'm not entirely clear that this is universal, but we got the following from installing on AWS linux:

        file /var/run from install of BLAH conflicts with file from package filesystem-2.4.30-3.8.amzn1.x86_64 