### PR TITLE
Revert back to 32 bit inode values

### DIFF
--- a/src/main/java/org/redline_rpm/header/Header.java
+++ b/src/main/java/org/redline_rpm/header/Header.java
@@ -85,7 +85,7 @@ public class Header extends AbstractHeader {
 		FILEUSERNAME( 1039, STRING_ARRAY_ENTRY, "fileusername"),
 		FILEGROUPNAME( 1040, STRING_ARRAY_ENTRY, "filegroupname"),
 		FILEDEVICES( 1095, INT32_ENTRY, "filedevices"),
-		FILEINODES( 1096, INT64_ENTRY, "fileinodes"),
+		FILEINODES( 1096, INT32_ENTRY, "fileinodes"),
 		FILELANGS( 1097, STRING_ARRAY_ENTRY, "filelangs"),
 		PREFIXES( 1098, STRING_ARRAY_ENTRY, "prefixes"),
 		DIRINDEXES( 1116, INT32_ENTRY, "dirindexes"),

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -738,8 +738,8 @@ public class Contents {
 	 * Gets the inodes header values.
 	 * @return the iNodes header values
 	 */
-	public long[] getInodes() {
-		long[] array = new long[ headers.size()];
+	public int[] getInodes() {
+		int[] array = new int[ headers.size()];
 		int x = 0;
 		for ( CpioHeader header : headers) array[ x++] = header.getInode();
 		return array;

--- a/src/main/java/org/redline_rpm/payload/CpioHeader.java
+++ b/src/main/java/org/redline_rpm/payload/CpioHeader.java
@@ -45,7 +45,7 @@ public class CpioHeader {
 
 	protected Charset charset = Charset.forName( "ASCII");
 
-	protected long inode;
+	protected int inode;
 	protected int type;
 	protected int permissions = DEFAULT_FILE_PERMISSION;
 	protected int uid;
@@ -102,7 +102,7 @@ public class CpioHeader {
 	public int getDevMajor() { return devMajor; }
 	public int getDevMinor() { return devMinor; }
 	public int getMtime() { return ( int) ( mtime / 1000L) ; }
-	public long getInode() { return inode; }
+	public int getInode() { return inode; }
 	public String getName() { return name; }
 	public int getFlags() { return flags; }
 	public int getVerifyFlags() { return verifyFlags; }
@@ -113,7 +113,7 @@ public class CpioHeader {
 	public void setType( int type) { this.type = type; }
 	public void setFileSize( int filesize) { this.filesize = filesize; }
 	public void setMtime( long mtime) { this.mtime = mtime; }
-	public void setInode( long inode) { this.inode = inode; }
+	public void setInode( int inode) { this.inode = inode; }
 	public void setFlags( int flags) { this.flags = flags; }
 	public void setVerifyFlags( int verifyFlags) { this.verifyFlags = verifyFlags; }
 
@@ -148,10 +148,6 @@ public class CpioHeader {
 		return charset.encode( pad( data, 6));
 	}
 
-	protected ByteBuffer writeEight( long data) {
-		return charset.encode( pad( Long.toHexString( data), 8));
-	}
-
 	protected ByteBuffer writeEight( int data) {
 		return charset.encode( pad( Integer.toHexString( data), 8));
 	}
@@ -160,8 +156,8 @@ public class CpioHeader {
 		return readChars( buffer, 6);
 	}
 
-	protected Long readEight( CharBuffer buffer) {
-		return Long.parseLong( readChars( buffer, 8).toString(), 16);
+	protected int readEight( CharBuffer buffer) {
+		return Integer.parseInt( readChars( buffer, 8).toString(), 16);
 	}
 
 	protected CharSequence readChars( CharBuffer buffer, int length) {
@@ -201,21 +197,21 @@ public class CpioHeader {
 		if ( !MAGIC.equals(magic.toString())) throw new IllegalStateException( "Invalid magic number '" + magic + "' of length '" + magic.length() + "'.");
 		inode = readEight( buffer);
 		
-		final int mode = readEight( buffer).intValue();
+		final int mode = readEight( buffer);
 		permissions = mode & 07777;
 		type = mode >>> 12;
 		
-		uid = readEight( buffer).intValue();
-		gid = readEight( buffer).intValue();
-		nlink = readEight( buffer).intValue();
-		mtime = 1000L * readEight( buffer).intValue();
-		filesize = readEight( buffer).intValue();
-		devMajor = readEight( buffer).intValue();
-		devMinor = readEight( buffer).intValue();
-		rdevMajor = readEight( buffer).intValue();
-		rdevMinor = readEight( buffer).intValue();
-		int namesize = readEight( buffer).intValue();
-		checksum = readEight( buffer).intValue();
+		uid = readEight( buffer);
+		gid = readEight( buffer);
+		nlink = readEight( buffer);
+		mtime = 1000L * readEight( buffer);
+		filesize = readEight( buffer);
+		devMajor = readEight( buffer);
+		devMinor = readEight( buffer);
+		rdevMajor = readEight( buffer);
+		rdevMinor = readEight( buffer);
+		int namesize = readEight( buffer);
+		checksum = readEight( buffer);
 		total += CPIO_HEADER;
 
 		name = charset.decode( Util.fill( channel, namesize - 1)).toString();


### PR DESCRIPTION
I was hitting issue #97 and switching the inode values from 64 bit back to 32 has solved it for me.

The rpms created with this change install fine on both CentOS 5 with RPM 4.4 and CentOS 7 with RPM 4.11.