### PR TITLE
Add PPC64LE as an architecture to support OpenPower Platforms

### DIFF
--- a/src/main/java/org/redline_rpm/header/Architecture.java
+++ b/src/main/java/org/redline_rpm/header/Architecture.java
@@ -19,6 +19,7 @@ public enum Architecture {
 	S390,
 	S390X,
 	PPC64,
+	PPC64LE,
 	SH,
 	XTENSA,
 	X86_64


### PR DESCRIPTION
When trying to package rpms of Architecture type ppc64le (OpenPower) a failure occurs stating it is not a supported architecture

I added PPC64LE as an architecure type so downstream dependencies of redline will be able to build rpm's for distro's running ppc64le

Specifically https://github.com/nebula-plugins/gradle-ospackage-plugin needs this update to enable packaging with Gradle for OpenPower

Please prioritize this pull request since its very small and enables our blocked workflows

Thanks,
Kyle Johnson
IBM