### PR TITLE
Fix 109 duplicate provides

### DIFF
--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -13,7 +13,6 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +69,7 @@ public class Builder {
 	protected final List< Dependency> requires = new LinkedList< Dependency>();
 	protected final List< Dependency> obsoletes = new LinkedList< Dependency>();
 	protected final List< Dependency> conflicts = new LinkedList< Dependency>();
-	protected final Map< String, Dependency> provides = new LinkedHashMap< String, Dependency>();
+	protected final List< Dependency> provides = new LinkedList< Dependency>();
 
 	protected final List< String> triggerscripts = new LinkedList< String>();
 	protected final List< String> triggerscriptprogs = new LinkedList< String>();
@@ -150,11 +149,11 @@ public class Builder {
 	}
 	
 	public void addProvides(final String name, final String version) {
-		provides.put(name, new Dependency(name, version, version.length() > 0 ? EQUAL : 0));
+		provides.add(new Dependency(name, version, version.length() > 0 ? EQUAL : 0));
 	}
 
 	protected void addProvides(final CharSequence name, final CharSequence version, final int flag) {
-		provides.put(name.toString(), new Dependency(name.toString(), version.toString(), flag));
+		provides.add(new Dependency(name.toString(), version.toString(), flag));
 	}
 	
 	/**

--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -13,6 +13,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class Builder {
 	protected final List< Dependency> requires = new LinkedList< Dependency>();
 	protected final List< Dependency> obsoletes = new LinkedList< Dependency>();
 	protected final List< Dependency> conflicts = new LinkedList< Dependency>();
-	protected final List< Dependency> provides = new LinkedList< Dependency>();
+	protected final Map< String, Dependency> provides = new LinkedHashMap< String, Dependency>();
 
 	protected final List< String> triggerscripts = new LinkedList< String>();
 	protected final List< String> triggerscriptprogs = new LinkedList< String>();
@@ -149,11 +150,11 @@ public class Builder {
 	}
 	
 	public void addProvides(final String name, final String version) {
-		provides.add(new Dependency(name, version, version.length() > 0 ? EQUAL : 0));
+		provides.put(name, new Dependency(name, version, version.length() > 0 ? EQUAL : 0));
 	}
 
 	protected void addProvides(final CharSequence name, final CharSequence version, final int flag) {
-		provides.add(new Dependency(name.toString(), version.toString(), flag));
+		provides.put(name.toString(), new Dependency(name.toString(), version.toString(), flag));
 	}
 	
 	/**

--- a/src/main/java/org/redline_rpm/Dependency.java
+++ b/src/main/java/org/redline_rpm/Dependency.java
@@ -2,7 +2,6 @@ package org.redline_rpm;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class represents a RPM dependency.
@@ -90,53 +89,4 @@ public class Dependency {
 
         return flagsList.toArray(new Integer[flagsList.size()]);
     }
-  
-    /**
-     * Returns an array of String with the name of every dependency from a list of dependencies.
-     * @param dependencies    List of dependencies
-     * @return String[] with all names of the dependencies
-     */
-    public static String[] getArrayOfNames(Map< String, Dependency> dependencies) {
-        List<String> nameList = new LinkedList<String>();
-
-        for (Dependency dependency : dependencies.values()) {
-            nameList.add(dependency.getName());
-        }
-
-        return nameList.toArray(new String[nameList.size()]);
-    }
-
-    /**
-     * Returns an array of String with the version of every dependency from a list of dependencies.
-     * @param dependencies    List of dependencies
-     * @return String[] with all versions of the dependencies
-     */
-    public static String[] getArrayOfVersions(Map< String, Dependency> dependencies) {
-        List<String> versionList = new LinkedList<String>();
-
-        for (Dependency dependency : dependencies.values()) {
-            versionList.add(dependency.getVersion());
-        }
-
-        return versionList.toArray(new String[versionList.size()]);
-    }
-
-    /**
-     * Returns an array of Integer with the flags of every dependency from a list of dependencies.
-     * @param dependencies    List of dependencies
-     * @return Integer[] with all flags of the dependencies
-     */
-    public static Integer[] getArrayOfFlags(Map< String, Dependency> dependencies) {
-        List<Integer> flagsList = new LinkedList<Integer>();
-
-        for (Dependency dependency : dependencies.values()) {
-            flagsList.add(dependency.getFlags());
-        }
-
-        return flagsList.toArray(new Integer[flagsList.size()]);
-    }
 }
-
-    
-    
-

--- a/src/main/java/org/redline_rpm/Dependency.java
+++ b/src/main/java/org/redline_rpm/Dependency.java
@@ -2,6 +2,7 @@ package org.redline_rpm;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class represents a RPM dependency.
@@ -89,4 +90,53 @@ public class Dependency {
 
         return flagsList.toArray(new Integer[flagsList.size()]);
     }
+  
+    /**
+     * Returns an array of String with the name of every dependency from a list of dependencies.
+     * @param dependencies    List of dependencies
+     * @return String[] with all names of the dependencies
+     */
+    public static String[] getArrayOfNames(Map< String, Dependency> dependencies) {
+        List<String> nameList = new LinkedList<String>();
+
+        for (Dependency dependency : dependencies.values()) {
+            nameList.add(dependency.getName());
+        }
+
+        return nameList.toArray(new String[nameList.size()]);
+    }
+
+    /**
+     * Returns an array of String with the version of every dependency from a list of dependencies.
+     * @param dependencies    List of dependencies
+     * @return String[] with all versions of the dependencies
+     */
+    public static String[] getArrayOfVersions(Map< String, Dependency> dependencies) {
+        List<String> versionList = new LinkedList<String>();
+
+        for (Dependency dependency : dependencies.values()) {
+            versionList.add(dependency.getVersion());
+        }
+
+        return versionList.toArray(new String[versionList.size()]);
+    }
+
+    /**
+     * Returns an array of Integer with the flags of every dependency from a list of dependencies.
+     * @param dependencies    List of dependencies
+     * @return Integer[] with all flags of the dependencies
+     */
+    public static Integer[] getArrayOfFlags(Map< String, Dependency> dependencies) {
+        List<Integer> flagsList = new LinkedList<Integer>();
+
+        for (Dependency dependency : dependencies.values()) {
+            flagsList.add(dependency.getFlags());
+        }
+
+        return flagsList.toArray(new Integer[flagsList.size()]);
+    }
 }
+
+    
+    
+

--- a/src/test/java/org/redline_rpm/BuilderTest.java
+++ b/src/test/java/org/redline_rpm/BuilderTest.java
@@ -179,6 +179,34 @@ public class BuilderTest extends TestBase {
         assertArrayEquals(new    int[] { LESS            }, Arrays.copyOfRange(requireflags, requireflags.length - 1, require.length));
         assertArrayEquals(new String[] { "2.0"           }, Arrays.copyOfRange(requireversion, requireversion.length - 1, require.length));
     }
+    
+    @Test
+    public void testProvideOverride() throws Exception {
+        Builder builder = new Builder();
+        builder.setPackage("testProvideOverride", "1.0", "1");
+        builder.setBuildHost("localhost");
+        builder.setLicense("GPL");
+        builder.setPlatform(NOARCH, LINUX);
+        builder.setType(BINARY);
+        
+        // add a provide of the same name as the one created by setPackage().
+        // only one provide entry should appear in the RPM.
+        builder.addProvides("testProvideOverride", "1.0");
+
+        builder.build( new File( getTargetDir()));
+
+        Format format = new Scanner().run(channelWrapper("target" + File.separator + "testProvideOverride-1.0-1.noarch.rpm"));
+
+        String[] provide = (String[])format.getHeader().getEntry(HeaderTag.PROVIDENAME).getValues();
+        int[] provideflags = (int[])format.getHeader().getEntry(HeaderTag.PROVIDEFLAGS).getValues();
+        String[] provideversion = (String[])format.getHeader().getEntry(HeaderTag.PROVIDEVERSION).getValues();
+
+        assertEquals( 1, provide.length);
+        assertArrayEquals(new String[] { "testProvideOverride"}, Arrays.copyOfRange(provide, 0, provide.length));
+        assertArrayEquals(new    int[] { EQUAL                }, Arrays.copyOfRange(provideflags, 0, provide.length));
+        assertArrayEquals(new String[] { "1.0"                }, Arrays.copyOfRange(provideversion, 0, provide.length));
+    }
+
     @Test
     public void testAddHeaderEntry() {
     	Builder builder = new Builder();

--- a/src/test/java/org/redline_rpm/BuilderTest.java
+++ b/src/test/java/org/redline_rpm/BuilderTest.java
@@ -179,34 +179,6 @@ public class BuilderTest extends TestBase {
         assertArrayEquals(new    int[] { LESS            }, Arrays.copyOfRange(requireflags, requireflags.length - 1, require.length));
         assertArrayEquals(new String[] { "2.0"           }, Arrays.copyOfRange(requireversion, requireversion.length - 1, require.length));
     }
-    
-    @Test
-    public void testProvideOverride() throws Exception {
-        Builder builder = new Builder();
-        builder.setPackage("testProvideOverride", "1.0", "1");
-        builder.setBuildHost("localhost");
-        builder.setLicense("GPL");
-        builder.setPlatform(NOARCH, LINUX);
-        builder.setType(BINARY);
-        
-        // add a provide of the same name as the one created by setPackage().
-        // only one provide entry should appear in the RPM.
-        builder.addProvides("testProvideOverride", "1.0");
-
-        builder.build( new File( getTargetDir()));
-
-        Format format = new Scanner().run(channelWrapper("target" + File.separator + "testProvideOverride-1.0-1.noarch.rpm"));
-
-        String[] provide = (String[])format.getHeader().getEntry(HeaderTag.PROVIDENAME).getValues();
-        int[] provideflags = (int[])format.getHeader().getEntry(HeaderTag.PROVIDEFLAGS).getValues();
-        String[] provideversion = (String[])format.getHeader().getEntry(HeaderTag.PROVIDEVERSION).getValues();
-
-        assertEquals( 1, provide.length);
-        assertArrayEquals(new String[] { "testProvideOverride"}, Arrays.copyOfRange(provide, 0, provide.length));
-        assertArrayEquals(new    int[] { EQUAL                }, Arrays.copyOfRange(provideflags, 0, provide.length));
-        assertArrayEquals(new String[] { "1.0"                }, Arrays.copyOfRange(provideversion, 0, provide.length));
-    }
-
     @Test
     public void testAddHeaderEntry() {
     	Builder builder = new Builder();

--- a/src/test/java/org/redline_rpm/BuilderTest.java
+++ b/src/test/java/org/redline_rpm/BuilderTest.java
@@ -165,6 +165,7 @@ public class BuilderTest extends TestBase {
         builder.setType(BINARY);
         builder.addDependency("httpd", GREATER | EQUAL, "1.0");
         builder.addDependency("httpd", LESS, "2.0");
+
         builder.build( new File( getTargetDir()));
 
         Format format = new Scanner().run(channelWrapper("target" + File.separator + "testMultipleCapabilities-1.0-1.noarch.rpm"));
@@ -179,6 +180,31 @@ public class BuilderTest extends TestBase {
         assertArrayEquals(new    int[] { LESS            }, Arrays.copyOfRange(requireflags, requireflags.length - 1, require.length));
         assertArrayEquals(new String[] { "2.0"           }, Arrays.copyOfRange(requireversion, requireversion.length - 1, require.length));
     }
+    @Test
+    public void testProvideOverride() throws Exception {
+        Builder builder = new Builder();
+        builder.setPackage("testProvideOverride", "1.0", "1");
+        builder.setBuildHost("localhost");
+        builder.setLicense("GPL");
+        builder.setPlatform(NOARCH, LINUX);
+        builder.setType(BINARY);
+        builder.addProvides("testProvideOverride", "1.0");
+
+        builder.build( new File( getTargetDir()));
+
+        Format format = new Scanner().run(channelWrapper("target" + File.separator + "testProvideOverride-1.0-1.noarch.rpm"));
+
+        String[] provide = (String[])format.getHeader().getEntry(HeaderTag.PROVIDENAME).getValues();
+        int[] provideflags = (int[])format.getHeader().getEntry(HeaderTag.PROVIDEFLAGS).getValues();
+        String[] provideversion = (String[])format.getHeader().getEntry(HeaderTag.PROVIDEVERSION).getValues();
+
+        assertEquals( 1, provide.length);
+        assertArrayEquals(new String[] { "testProvideOverride"}, Arrays.copyOfRange(provide, 0, provide.length));
+        assertArrayEquals(new    int[] { EQUAL                }, Arrays.copyOfRange(provideflags, 0, provide.length));
+        assertArrayEquals(new String[] { "1.0"                }, Arrays.copyOfRange(provideversion, 0, provide.length));
+
+    }
+
     @Test
     public void testAddHeaderEntry() {
     	Builder builder = new Builder();


### PR DESCRIPTION
This is my initial implementation of a Fix for [redline-1.2.3 breaks gradle-ospackage-plugin test suite #109](https://github.com/craigwblake/redline/issues/109).  It may be considered as an opening for further discussion, or possibly sufficient as is.

It changes
	`protected final List< Dependency> provides = new LinkedList< Dependency>();`
to
	`protected final Map< String, Dependency> provides = new LinkedHashMap< String, Dependency>();`

and makes other changes required by this.  It also includes a new test case, `BuilderTest.testProvideOverride()`.  This test fails with the old code and is roughly equivalent to gradle-ospackage-plugin's test, which we clearly need.

It may not be complete.  A similar approach might also be correct for these other LinkedLists of Dependency objects in Builder:

```
	protected final List< Dependency> requires = new LinkedList< Dependency>();
	protected final List< Dependency> obsoletes = new LinkedList< Dependency>();
	protected final List< Dependency> conflicts = new LinkedList< Dependency>();
```
 However, making the same change for these as was done for `provides` caused tests to fail.  Making the change only to `provides` allows the new test case `BuilderTest.testProvideOverride()` to pass.   Since this is the only issue reported by gradle-ospackage-plugin's tests, this may be sufficient.  Or else further changes may be advisable.