### PR TITLE
Allow ~ in Version and Release?

### DIFF
--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -61,7 +61,7 @@ public class Builder {
 
 	private static final String DEFAULTSCRIPTPROG = "/bin/sh";
 
-	private static final char[] ILLEGAL_CHARS_VARIABLE = new char[] { '-', '~', '/' };
+	private static final char[] ILLEGAL_CHARS_VARIABLE = new char[] { '-', '/' };
 	private static final char[] ILLEGAL_CHARS_NAME = new char[] { '/', ' ', '\t', '\n', '\r' };
 
 	protected final Format format = new Format();

--- a/src/test/java/org/redline_rpm/ant/RedlineTaskTest.java
+++ b/src/test/java/org/redline_rpm/ant/RedlineTaskTest.java
@@ -90,15 +90,6 @@ public class RedlineTaskTest extends TestBase {
 			// Pass
 		}
 
-		// test version with illegal char ~
-		task.setVersion("1.0~beta");
-		try {
-			task.execute();
-			fail();
-		} catch (IllegalArgumentException iae) {
-			// Pass
-		}
-
 		// test version with illegal char /
 		task.setVersion("1.0/beta");
 		try {
@@ -118,15 +109,6 @@ public class RedlineTaskTest extends TestBase {
 
 		// test release with illegal char -
 		task.setRelease("2-3");
-		try {
-			task.execute();
-			fail();
-		} catch (IllegalArgumentException iae) {
-			// Pass
-		}
-
-		// test release with illegal char ~
-		task.setRelease("2~3");
 		try {
 			task.execute();
 			fail();


### PR DESCRIPTION
Is it possible redline is being a bit too aggressive in validating version and release input?

Building a package with a `~` in the version or release causes redline to throw an exception. It looks like `-` is the only prohibited character in rpm versions and releases from [the docs at rpm.org](http://rpm.org/max-rpm-snapshot/ch-rpm-file-format.html):

> The only restriction placed on the version is that it cannot contain a dash "-".

> The release can be thought of as the package's version. [...] Like the version number, the only restriction is that dashes are not allowed.

If I build a package `nameRequired-1.0~beta-1.noarch.rpm`, running `rpm -qip` seems to correctly parse the version:

```
Name        : nameRequired                 Relocations: (not relocatable)
Version     : 1.0~beta                          Vendor: 
Release     : 1                             Build Date: Wed Dec 21 19:39:19 2016
Install Date: (not installed)               Build Host: sghill-mbp
Group       : groupRequired                 Source RPM: (none)
Size        : 0                                License: 
Signature   : (none)
Packager    : sghill
URL         : 
Summary     : 
Architecture: noarch
Description :
```

Context:
* #18 stated `-`, `/`, and `~` are illegal characters for rpm
* #39 implemented the feature
* https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/213 ran into the tilde issue
* a commenter on https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/49 ran into the tilde issue