### PR TITLE
fixed #114 #118

### DIFF
--- a/src/main/java/org/redline_rpm/payload/CpioHeader.java
+++ b/src/main/java/org/redline_rpm/payload/CpioHeader.java
@@ -43,7 +43,7 @@ public class CpioHeader {
 	protected static final String MAGIC = "070701";
 	protected static final String TRAILER = "TRAILER!!!";
 
-	protected Charset charset = Charset.forName( "ASCII");
+	protected Charset charset = Charset.forName( "UTF-8");
 
 	protected int inode;
 	protected int type;


### PR DESCRIPTION
Need for support non-latin filename charset
Also for [gradle-ospackage-plugin](https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/237)