### PR TITLE
Added method to set signature size

### DIFF
--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -89,10 +89,11 @@ public class Builder {
 	protected final Entry< byte[]> immutable = ( Entry< byte[]>) format.getHeader().addEntry( HEADERIMMUTABLE, 16);
 
 	protected Contents contents = new Contents();
-    protected File privateKeyRingFile;
-    protected String privateKeyId;
-    protected String privateKeyPassphrase;
-    protected PGPPrivateKey privateKey;
+  protected File privateKeyRingFile;
+  protected String privateKeyId;
+  protected String privateKeyPassphrase;
+  protected PGPPrivateKey privateKey;
+  protected int signatureSize = 287;
 
 	/**
 	 * Initializes the builder and sets some required fields to known values.
@@ -1220,6 +1221,15 @@ public class Builder {
     public void setPrivateKey( PGPPrivateKey privateKey ) {
         this.privateKey = privateKey;
     }
+    
+     /**
+     * Sets the signature size for generating keys with different RSA headers. 
+     * This should only be used if the exact size of the header is known. 
+     * @param signatureSize the signature size
+     */
+    public void setSignatureSize( int signatureSize ) {
+        this.signatureSize = signatureSize;
+    }
 
     /**
 	 * Generates an RPM with a standard name consisting of the RPM package name, version, release,
@@ -1398,9 +1408,9 @@ public class Builder {
 
     protected SignatureGenerator createSignatureGenerator() {
         if (privateKey != null) {
-           return new SignatureGenerator( privateKey );
+           return new SignatureGenerator( privateKey, signatureSize );
         }
-        return new SignatureGenerator( privateKeyRingFile, privateKeyId, privateKeyPassphrase);
+        return new SignatureGenerator( privateKeyRingFile, privateKeyId, privateKeyPassphrase, signatureSize );
     }
 
     protected byte[] getSignature( final int count) {

--- a/src/main/java/org/redline_rpm/SignatureGenerator.java
+++ b/src/main/java/org/redline_rpm/SignatureGenerator.java
@@ -30,7 +30,7 @@ import static org.redline_rpm.header.Signature.SignatureTag.RSAHEADER;
  */
 public class SignatureGenerator {
 
-    protected static final int SIGNATURE_SIZE = 287;
+    protected int signatureSize;
     protected final boolean enabled;
     protected Entry< byte[]> headerOnlyRSAEntry;
     protected Entry< byte[]> headerAndPayloadPGPEntry;
@@ -39,12 +39,14 @@ public class SignatureGenerator {
     protected Key< byte[]> headerAndPayloadKey = null;
     private Logger logger = getLogger( SignatureGenerator.class.getName());
 
-    public SignatureGenerator( PGPPrivateKey privateKey ) {
+    public SignatureGenerator( PGPPrivateKey privateKey, int signatureSize ) {
         this.privateKey = privateKey;
         this.enabled = privateKey != null;
+        this.signatureSize = signatureSize > 0 ? signatureSize : 287;
     }
 
-    public SignatureGenerator( File privateKeyRingFile, String privateKeyId, String privateKeyPassphrase ) {
+    public SignatureGenerator( File privateKeyRingFile, String privateKeyId, String privateKeyPassphrase, int signatureSize ) {
+        this.signatureSize = signatureSize > 0 ? signatureSize : 287;
         if ( privateKeyRingFile != null ) {
             PGPSecretKeyRingCollection keyRings = readKeyRings( privateKeyRingFile );
             PGPSecretKey secretKey = findMatchingSecretKey( keyRings, privateKeyId );
@@ -63,8 +65,8 @@ public class SignatureGenerator {
     @SuppressWarnings("unchecked")
 	public void prepare( Signature signature ) {
         if ( enabled ) {
-            headerOnlyRSAEntry = ( Entry< byte[]> ) signature.addEntry( RSAHEADER, SIGNATURE_SIZE );
-            headerAndPayloadPGPEntry = ( Entry< byte[]> ) signature.addEntry( LEGACY_PGP, SIGNATURE_SIZE );
+            headerOnlyRSAEntry = ( Entry< byte[]> ) signature.addEntry( RSAHEADER, signatureSize );
+            headerAndPayloadPGPEntry = ( Entry< byte[]> ) signature.addEntry( LEGACY_PGP, signatureSize );
         }
     }
 

--- a/src/test/java/org/redline_rpm/SignatureGeneratorTest.java
+++ b/src/test/java/org/redline_rpm/SignatureGeneratorTest.java
@@ -10,13 +10,13 @@ public class SignatureGeneratorTest extends TestBase {
 
     @Test
     public void testReadingFirstKey() throws Exception {
-        SignatureGenerator generator = new SignatureGenerator( new File( getFileResource( "/pgp/secring.gpg" ) ), null, "redline" );
+        SignatureGenerator generator = new SignatureGenerator( new File( getFileResource( "/pgp/secring.gpg" ) ), null, "redline", 287 );
         assertTrue( generator.isEnabled() );
     }
 
     @Test
     public void testFindByKey() throws Exception {
-        SignatureGenerator generator = new SignatureGenerator( new File( getFileResource( "/pgp/secring.gpg" )), "5A186608", "redline" );
+        SignatureGenerator generator = new SignatureGenerator( new File( getFileResource( "/pgp/secring.gpg" )), "5A186608", "redline", 287 );
         assertTrue( generator.isEnabled() );
     }
 }


### PR DESCRIPTION
Until a proven method of calculating what the header size should be, allow a custom signature size to be specified.

Fixes #62 