### PR TITLE
correct issue #123 (builtin usable inside ant script)

### DIFF
--- a/src/main/java/org/redline_rpm/ant/BuiltIn.java
+++ b/src/main/java/org/redline_rpm/ant/BuiltIn.java
@@ -1,23 +1,15 @@
 package org.redline_rpm.ant;
 
-import org.apache.tools.ant.Project;
-
 public class BuiltIn {
 	
-	private final Project project;
+	private String directory;
 	
-	private String name;
-	
-	public BuiltIn( Project project) {
-		this.project = project;
+	public void setDirectory( String text) {
+		this.directory = text;
 	}
 	
-	public void addText( String text) {
-		this.name = project.replaceProperties(text);
-	}
-	
-	public String getText() {
-		return name;
+	public String getDirectory() {
+		return directory;
 	}
 
 }

--- a/src/main/java/org/redline_rpm/ant/RedlineTask.java
+++ b/src/main/java/org/redline_rpm/ant/RedlineTask.java
@@ -131,9 +131,9 @@ public class RedlineTask extends Task {
 		
 		// add built-ins
 		for ( BuiltIn builtIn : builtIns) {
-			String text = builtIn.getText();
+			String text = builtIn.getDirectory();
 			if (text != null && !text.trim().equals("")) {
-				builder.addBuiltinDirectory( builtIn.getText());
+				builder.addBuiltinDirectory( builtIn.getDirectory());
 			}
 		}
 

--- a/src/main/java/org/redline_rpm/changelog/ChangelogParser.java
+++ b/src/main/java/org/redline_rpm/changelog/ChangelogParser.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * This object reads the Changelog file and attempts to parse its
@@ -19,7 +20,7 @@ import java.util.List;
  *
  */
 class ChangelogParser {
-	static final SimpleDateFormat fmt = new SimpleDateFormat("EEE MMM dd yyyy");
+	static final SimpleDateFormat fmt = new SimpleDateFormat("EEE MMM dd yyyy", Locale.ENGLISH);
 	/**
 	 * @param lines an array of lines read from the Changelog file
 	 * @return a List of ChangeLogEntry objects

--- a/src/test/java/org/redline_rpm/ant/RedlineTaskTest.java
+++ b/src/test/java/org/redline_rpm/ant/RedlineTaskTest.java
@@ -7,6 +7,7 @@ import java.nio.channels.Channels;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -31,6 +32,8 @@ import static org.junit.Assert.*;
 
 public class RedlineTaskTest extends TestBase {
 
+	static final SimpleDateFormat fmt = new SimpleDateFormat("EEE MMM dd yyyy", Locale.ENGLISH);
+	
 	@Test
 	public void testBadName() throws Exception {
 			File dir = ensureTargetDir();
@@ -491,7 +494,7 @@ public class RedlineTaskTest extends TestBase {
 
 		assertArrayEquals("Entry value : " + tag.getName(), expected, values);
 	}
-	static final SimpleDateFormat fmt = new SimpleDateFormat("EEE MMM dd yyyy");
+	
 	private void assertDateEntryHeaderEqualsAt(String expected, Format format, AbstractHeader.Tag tag, int size, int pos) {
 		assertNotNull("null format", format);
 		AbstractHeader.Entry< ?> entry = format.getHeader().getEntry(tag);


### PR DESCRIPTION
make tests work with local timezone other than english, 
make builtin work inside ant script with syntax <builtin directory="dir"/>