### PR TITLE
Added field addParents to support overriding this in ant task

### DIFF
--- a/src/main/java/org/redline_rpm/ant/RedlineTask.java
+++ b/src/main/java/org/redline_rpm/ant/RedlineTask.java
@@ -175,6 +175,7 @@ public class RedlineTask extends Task {
 				String username = null;
 				String group = null;
                 Directive directive = null;
+                boolean addParents = true;
 
 				if (fileset instanceof TarFileSet) {
 					TarFileSet tarFileSet = (TarFileSet)fileset;
@@ -185,6 +186,11 @@ public class RedlineTask extends Task {
                         directive = rpmFileSet.getDirective();
                     }
 				}
+
+                if (fileset instanceof RpmFileSet) {
+                    RpmFileSet rpmFileSet = (RpmFileSet) fileset;
+                    addParents = rpmFileSet.getAddParents();
+                }
 
 				// include any directories, including empty ones, duplicates will be ignored when we scan included files
 				for (String entry : scanner.getIncludedDirectories()) {
@@ -198,7 +204,7 @@ public class RedlineTask extends Task {
 						builder.addURL( prefix + entry, url, filemode, dirmode, directive, username, group);
 					} else {
 						File file = new File( scanner.getBasedir(), entry);
-						builder.addFile(prefix + entry, file, filemode, dirmode, directive, username, group);
+						builder.addFile(prefix + entry, file, filemode, dirmode, directive, username, group, addParents);
 					}
 				}
 			}

--- a/src/main/java/org/redline_rpm/ant/RpmFileSet.java
+++ b/src/main/java/org/redline_rpm/ant/RpmFileSet.java
@@ -18,6 +18,11 @@ public class RpmFileSet extends TarFileSet {
     private Directive directive = new Directive();
 
     /**
+     * Whether to create parent directories for the file. Defaults to true.
+     */
+    private boolean addParents = true;
+
+    /**
      * Constructor for {@code RpmFileSet}
      */
     public RpmFileSet() {
@@ -168,5 +173,13 @@ public class RpmFileSet extends TarFileSet {
                 instanceof RpmFileSet))) {
             checkAttributesAllowed();
         }
+    }
+
+    public boolean getAddParents() {
+        return addParents;
+    }
+
+    public void setAddParents(boolean addParents) {
+        this.addParents = addParents;
     }
 }


### PR DESCRIPTION
We would like to be able to use the overloaded method addFile when invoking via the Ant task. This minor addition provides this support.