### PR TITLE
Add AARCH64 as an architecture to support Arm64 platform

### DIFF
--- a/src/main/java/org/redline_rpm/header/Architecture.java
+++ b/src/main/java/org/redline_rpm/header/Architecture.java
@@ -22,5 +22,6 @@ public enum Architecture {
 	SH,
 	XTENSA,
 	X86_64,
-	PPC64LE
+	PPC64LE,
+	AARCH64
 }


### PR DESCRIPTION
We failed to generate aarch64 rpm when using the nebula ospackage
plugin. Adding `aarch64` as a supported arch should fix the issue.