### PR TITLE
bump bcpg-jdk15on to 1.69 because 1.62 contains vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.4</version>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <shadedClassifierName>shaded-jar</shadedClassifierName>
@@ -221,7 +221,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpg-jdk15on</artifactId>
-			<version>1.62</version>
+			<version>1.69</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The Bouncycastle libraries contain some vulnerabilities as reported here:
https://snyk.io/vuln/maven:org.bouncycastle:bcprov-jdk15on

Upgrading to the latest version 1.69 required a bump in the maven-shade-plugin, too.