### PR TITLE
Add SHA256 support

### DIFF
--- a/src/main/java/org/redline_rpm/SignatureGenerator.java
+++ b/src/main/java/org/redline_rpm/SignatureGenerator.java
@@ -105,16 +105,17 @@ public class SignatureGenerator {
 
     protected PGPSecretKey findMatchingSecretKey( PGPSecretKeyRingCollection keyRings, String privateKeyId ) {
         privateKeyId = privateKeyId != null ? privateKeyId.toLowerCase() : null;
-
+        System.out.println("keyRings.size() = " + keyRings.size());
         @SuppressWarnings( "unchecked" )
         Iterator< PGPSecretKeyRing> iter = keyRings.getKeyRings();
         while ( iter.hasNext() ) {
             PGPSecretKeyRing keyRing = iter.next();
-
+            System.out.println("keyRing = " + keyRing);
             @SuppressWarnings( "unchecked" )
             Iterator< PGPSecretKey> keyIter = keyRing.getSecretKeys();
             while ( keyIter.hasNext() ) {
                 PGPSecretKey key = keyIter.next();
+                System.out.println("key = " + key + " -- " + key.isSigningKey());
                 if ( key.isSigningKey() && isMatchingKeyId( key, privateKeyId ) ) {
                     return key;
                 }
@@ -125,10 +126,11 @@ public class SignatureGenerator {
     }
 
     protected boolean isMatchingKeyId( PGPSecretKey key, String privateKeyId ) {
+        System.out.println("privateKeyId = " + privateKeyId);
         if (privateKeyId == null) {
             return true;
         }
-
+        System.out.println("Long.toHexString( key.getKeyID() ) = " + Long.toHexString(key.getKeyID()));
         return Long.toHexString( key.getKeyID() ).endsWith( privateKeyId );
     }
 

--- a/src/main/java/org/redline_rpm/SignatureGenerator.java
+++ b/src/main/java/org/redline_rpm/SignatureGenerator.java
@@ -105,17 +105,16 @@ public class SignatureGenerator {
 
     protected PGPSecretKey findMatchingSecretKey( PGPSecretKeyRingCollection keyRings, String privateKeyId ) {
         privateKeyId = privateKeyId != null ? privateKeyId.toLowerCase() : null;
-        System.out.println("keyRings.size() = " + keyRings.size());
+
         @SuppressWarnings( "unchecked" )
         Iterator< PGPSecretKeyRing> iter = keyRings.getKeyRings();
         while ( iter.hasNext() ) {
             PGPSecretKeyRing keyRing = iter.next();
-            System.out.println("keyRing = " + keyRing);
+
             @SuppressWarnings( "unchecked" )
             Iterator< PGPSecretKey> keyIter = keyRing.getSecretKeys();
             while ( keyIter.hasNext() ) {
                 PGPSecretKey key = keyIter.next();
-                System.out.println("key = " + key + " -- " + key.isSigningKey());
                 if ( key.isSigningKey() && isMatchingKeyId( key, privateKeyId ) ) {
                     return key;
                 }
@@ -126,11 +125,10 @@ public class SignatureGenerator {
     }
 
     protected boolean isMatchingKeyId( PGPSecretKey key, String privateKeyId ) {
-        System.out.println("privateKeyId = " + privateKeyId);
         if (privateKeyId == null) {
             return true;
         }
-        System.out.println("Long.toHexString( key.getKeyID() ) = " + Long.toHexString(key.getKeyID()));
+
         return Long.toHexString( key.getKeyID() ).endsWith( privateKeyId );
     }
 

--- a/src/main/java/org/redline_rpm/header/Header.java
+++ b/src/main/java/org/redline_rpm/header/Header.java
@@ -107,7 +107,6 @@ public class Header extends AbstractHeader {
 		DISTURL( 1123, STRING_ENTRY, "disturl"),
 		DISTTAG( 1155, STRING_ENTRY, "disttag"),
 
-		FILEDIGESTALGO( 5011, INT32_ENTRY, "filedigestalgo"),
 		BUGURL( 5012, STRING_ENTRY, "bugurl"),
 		ENCODING( 5062, STRING_ENTRY, "encoding"),
 		PAYLOADDIGEST( 5092, STRING_ARRAY_ENTRY, "payloaddigest"),

--- a/src/main/java/org/redline_rpm/header/Header.java
+++ b/src/main/java/org/redline_rpm/header/Header.java
@@ -79,7 +79,7 @@ public class Header extends AbstractHeader {
 		FILEMODES( 1030, INT16_ENTRY, "filemodes"),
 		FILERDEVS( 1033, INT16_ENTRY, "filerdevs"),
 		FILEMTIMES( 1034, INT32_ENTRY, "filemtimes"),
-		FILEMD5S( 1035, STRING_ARRAY_ENTRY, "filemd5s"),
+		FILEDIGESTS( 1035, STRING_ARRAY_ENTRY, "filedigests"),
 		FILELINKTOS( 1036, STRING_ARRAY_ENTRY, "filelinktos"),
 		FILEFLAGS( 1037, INT32_ENTRY, "fileflags"),
 		FILEUSERNAME( 1039, STRING_ARRAY_ENTRY, "fileusername"),
@@ -103,7 +103,16 @@ public class Header extends AbstractHeader {
 		PROVIDEFLAGS( 1112, INT32_ENTRY, "provideflags"),
 		PROVIDEVERSION( 1113, STRING_ARRAY_ENTRY, "provideversion"),
 		OBSOLETEFLAGS( 1114, INT32_ENTRY, "obsoleteflags"),
-		OBSOLETEVERSION( 1115, STRING_ARRAY_ENTRY, "obsoleteversion");
+		OBSOLETEVERSION( 1115, STRING_ARRAY_ENTRY, "obsoleteversion"),
+		DISTURL( 1123, STRING_ENTRY, "disturl"),
+		DISTTAG( 1155, STRING_ENTRY, "disttag"),
+
+		FILEDIGESTALGO( 5011, INT32_ENTRY, "filedigestalgo"),
+		BUGURL( 5012, STRING_ENTRY, "bugurl"),
+		ENCODING( 5062, STRING_ENTRY, "encoding"),
+		PAYLOADDIGEST( 5092, STRING_ARRAY_ENTRY, "payloaddigest"),
+		PAYLOADDIGESTALGO( 5093, INT32_ENTRY, "payloaddigestalgo"),
+		PAYLOADDIGESTALT( 5097, STRING_ARRAY_ENTRY, "payloaddigestalt");
 
 		private int code;
 		private int type;

--- a/src/main/java/org/redline_rpm/header/Signature.java
+++ b/src/main/java/org/redline_rpm/header/Signature.java
@@ -31,7 +31,8 @@ public class Signature extends AbstractHeader {
 		// RSA signature of just the header section, depends on PGP
 		RSAHEADER( 268, 7, "rsaheader"),
 		SHA256HEADER( 273, STRING_ENTRY, "sha256header"),
-		LEGACY_RSAHEADER( 1012, 7, "rsaheader");
+		LEGACY_RSAHEADER( 1012, 7, "rsaheader"),
+		FILEDIGESTALGO( 5011, INT32_ENTRY, "filedigestalgo");
 
 		private int code;
 		private int type;

--- a/src/main/java/org/redline_rpm/header/Signature.java
+++ b/src/main/java/org/redline_rpm/header/Signature.java
@@ -21,14 +21,16 @@ public class Signature extends AbstractHeader {
 		GPG( 262, 7, "gpg"),
 		LEGACY_GPG( 1005, 7, "gpg"),
 		PAYLOADSIZE( 1007, 4, "payloadsize"),
+		RESERVEDSPACE( 1008, 4, "reservedspace"),
 		// SHA digest of just the header section
-		SHA1HEADER( 269, 6, "sha1header"),
-		LEGACY_SHA1HEADER( 1010, 6, "sha1header"),
+		SHA1HEADER( 269, STRING_ENTRY, "sha1header"),
+		LEGACY_SHA1HEADER( 1010, STRING_ENTRY, "sha1header"),
 		// DSA signature of just the header section, depends on GPG
 		DSAHEADER( 267, 7, "dsaheader"),
 		LEGACY_DSAHEADER( 1011, 7, "dsaheader"),
 		// RSA signature of just the header section, depends on PGP
 		RSAHEADER( 268, 7, "rsaheader"),
+		SHA256HEADER( 273, STRING_ENTRY, "sha256header"),
 		LEGACY_RSAHEADER( 1012, 7, "rsaheader");
 
 		private int code;

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -608,7 +608,7 @@ public class Contents {
 	 * @throws NoSuchAlgorithmException if the algorithm isn't supported
 	 * @throws IOException there was an IO error
 	 */
-	public String[] getMD5s() throws NoSuchAlgorithmException, IOException {
+	public String[] getFileChecksums() throws NoSuchAlgorithmException, IOException {
 		/**
 		 * This could be more efficiently handled during the output phase using a filtering channel,
 		 * but would require placeholder values in the archive and some state. This is left for a
@@ -623,14 +623,14 @@ public class Contents {
 			if ( object instanceof File) {
 				FileInputStream fileInput = new FileInputStream(( File) object);
 				final ReadableChannelWrapper input = new ReadableChannelWrapper( fileInput.getChannel());
-				final Key< byte[]> key = input.start( "MD5");
+				final Key< byte[]> key = input.start( "SHA-256");
 				while ( input.read( buffer) != -1) buffer.rewind();
 				value = Util.hex(input.finish(key));
 				input.close();
 				fileInput.close();
 			} else if ( object instanceof URL) {
 				final ReadableChannelWrapper input = new ReadableChannelWrapper( Channels.newChannel((( URL) object).openConnection().getInputStream()));
-				final Key< byte[]> key = input.start( "MD5");
+				final Key< byte[]> key = input.start( "SHA-256");
 				while ( input.read( buffer) != -1) buffer.rewind();
 				value = Util.hex(input.finish(key));
 				input.close();


### PR DESCRIPTION
Hey there, this PR adds support for sha256 header and sha256 payload digests and should fix #155

This also changes the filedigestalgo to sha256 instead of using md5 which allows rpm packages to created with this tool to be installed on FIPS (see https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3781.pdf)  enabled environments.

I also added a few more explicit tags in the Header class and updating some naming changes there to make debugging simpler of third party rpms.
