### PR TITLE
Adding support for reproducible builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,18 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-rules</artifactId>
+			<version>1.19.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-lambda</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.5</version>

--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -102,9 +102,9 @@ public class Builder {
 	 */
 	public Builder() {
 		format.getHeader().createEntry( HEADERI18NTABLE, "C");
-        long sourceDateEpoch=0;
-        long buildTime = System.currentTimeMillis()/1000;
-        try {
+		long sourceDateEpoch=0;
+		long buildTime = System.currentTimeMillis()/1000;
+		try {
 			sourceDateEpoch = Long.parseLong(System.getenv("SOURCE_DATE_EPOCH"));
 		}catch(NumberFormatException e) {
 			// do nothing

--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -102,7 +102,17 @@ public class Builder {
 	 */
 	public Builder() {
 		format.getHeader().createEntry( HEADERI18NTABLE, "C");
-		format.getHeader().createEntry( BUILDTIME, ( int) ( System.currentTimeMillis() / 1000));
+        long sourceDateEpoch=0;
+        long buildTime = System.currentTimeMillis()/1000;
+        try {
+			sourceDateEpoch = Long.parseLong(System.getenv("SOURCE_DATE_EPOCH"));
+		}catch(NumberFormatException e) {
+			// do nothing
+		}
+		if(sourceDateEpoch!=0){
+			buildTime = sourceDateEpoch;
+		}
+		format.getHeader().createEntry( BUILDTIME, ( int)buildTime);
 		format.getHeader().createEntry( RPMVERSION, "4.4.2");
 		format.getHeader().createEntry( PAYLOADFORMAT, "cpio");
 		format.getHeader().createEntry( PAYLOADCOMPRESSOR, "gzip");


### PR DESCRIPTION
This PR adds optional support for ensuring that two RPMs created from the same source code create the exact same byte-for-byte RPM output. See https://reproducible-builds.org/ for details on why such a feature has value.

The only change that is needed in Redline to support this is to provide an override where the "Date Built" can be overridden by an environment variable.

The environment variable chosen follows the spec defined at https://reproducible-builds.org/docs/source-date-epoch/ . Therefore, you can override the default built date with the env variable `SOURCE_DATE_EPOCH`

A unit test is added to verify this new behavior by injecting a test environment variable.

If this PR is accepted, we may list this library to https://reproducible-builds.org/docs/jvm/

Limitations:
- Redline will still create different RPMs if the order in which files are added into the Builder are changed. However, that is not something that changes when redline is executed on different environments.
-  Make sure that the binaries that you package using Redline themselves are reproducible builds. 