### PR TITLE
Change SHA1 to SHA256 in signatures

### DIFF
--- a/src/main/java/org/redline_rpm/ChannelWrapper.java
+++ b/src/main/java/org/redline_rpm/ChannelWrapper.java
@@ -17,7 +17,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.Signature;
 
-import static org.bouncycastle.bcpg.HashAlgorithmTags.SHA1;
+import static org.bouncycastle.bcpg.HashAlgorithmTags.SHA256;
 import static org.bouncycastle.openpgp.PGPSignature.BINARY_DOCUMENT;
 
 /**
@@ -123,7 +123,7 @@ public abstract class ChannelWrapper {
      * @return reference to the new key added to the consumers
      */
     public Key<byte[]> start( final PGPPrivateKey key, int algorithm ) {
-        BcPGPContentSignerBuilder contentSignerBuilder = new BcPGPContentSignerBuilder( algorithm, SHA1 );
+        BcPGPContentSignerBuilder contentSignerBuilder = new BcPGPContentSignerBuilder( algorithm, SHA256 );
         final PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator( contentSignerBuilder );
         try {
             signatureGenerator.init( BINARY_DOCUMENT, key );


### PR DESCRIPTION
RPM in CentOS Stream 9 fails with RSA/SHA1 signatures.

```
warning: Signature not supported. Hash algorithm SHA1 not available.
    Header V4 RSA/SHA1 Signature, key ID 82573a7c: BAD
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 ALT digest: OK
    Payload SHA256 digest: OK
    V4 RSA/SHA1 Signature, key ID 82573a7c: BAD
    MD5 digest: OK
```

SHA1 has known weaknesses - so this change simply replaces it with SHA256, although a better solution would be to allow the user to specify.

```
    Header V4 RSA/SHA256 Signature, key ID 8f7a0cf1: OK
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 ALT digest: OK
    Payload SHA256 digest: OK
    V4 RSA/SHA256 Signature, key ID 8f7a0cf1: OK
    MD5 digest: OK
```