### PR TITLE
fix #68 - configuring digest algorithm for files

### DIFF
--- a/src/main/java/org/redline_rpm/Builder.java
+++ b/src/main/java/org/redline_rpm/Builder.java
@@ -29,10 +29,7 @@ import java.security.PrivateKey;
 import org.bouncycastle.openpgp.PGPPrivateKey;
 import org.redline_rpm.changelog.ChangelogHandler;
 import org.redline_rpm.changelog.ChangelogParseException;
-import org.redline_rpm.header.Architecture;
-import org.redline_rpm.header.Format;
-import org.redline_rpm.header.Os;
-import org.redline_rpm.header.RpmType;
+import org.redline_rpm.header.*;
 import org.redline_rpm.payload.Contents;
 import org.redline_rpm.payload.CpioHeader;
 import org.redline_rpm.payload.Directive;
@@ -96,7 +93,7 @@ public class Builder {
     protected String privateKeyId;
     protected String privateKeyPassphrase;
     protected PGPPrivateKey privateKey;
-
+	protected FileDigestsAlg fileDigestsAlg = FileDigestsAlg.SHA256;
 	/**
 	 * Initializes the builder and sets some required fields to known values.
 	 */
@@ -1213,6 +1210,10 @@ public class Builder {
         this.privateKeyPassphrase = privateKeyPassphrase;
     }
 
+	public void setFileDigestAlg(FileDigestsAlg alg){
+		this.fileDigestsAlg = alg;
+	}
+
     /**
      * Sets the private key for header and payload signing directly. Alternatively, you can set
      * {@link #setPrivateKeyRingFile(java.io.File) key ring file}, {@link #setPrivateKeyId(String) key id}
@@ -1300,8 +1301,8 @@ public class Builder {
 		}
 
 		if (0 < contents.size()) {
-			String[] checksums = contents.getFileChecksums();
-			format.getHeader().createEntry(FILEDIGESTALGO, 8);
+			String[] checksums = contents.getFileChecksums(fileDigestsAlg);
+			format.getHeader().createEntry(FILEDIGESTALGO, fileDigestsAlg.getCode());
 			format.getHeader().createEntry(PAYLOADDIGESTALGO, 8);
 			format.getHeader().createEntry(FILEDIGESTS, checksums);
 			format.getHeader().createEntry(FILESIZES, contents.getSizes());

--- a/src/main/java/org/redline_rpm/header/FileDigestsAlg.java
+++ b/src/main/java/org/redline_rpm/header/FileDigestsAlg.java
@@ -1,0 +1,25 @@
+package org.redline_rpm.header;
+
+public enum FileDigestsAlg {
+
+    MD5(1, "MD5"),
+    SHA1(2, "SHA-1"),
+    SHA256(8, "SHA-256"),
+    SHA384(9, "SHA-384"),
+    SHA512(10, "SHA-512");
+
+    private final int code;
+    private final String algName;
+    FileDigestsAlg(int code, String algName){
+        this.code = code;
+        this.algName = algName;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getAlgName() {
+        return algName;
+    }
+}

--- a/src/main/java/org/redline_rpm/payload/Contents.java
+++ b/src/main/java/org/redline_rpm/payload/Contents.java
@@ -3,6 +3,7 @@ package org.redline_rpm.payload;
 import org.redline_rpm.ChannelWrapper.Key;
 import org.redline_rpm.ReadableChannelWrapper;
 import org.redline_rpm.Util;
+import org.redline_rpm.header.FileDigestsAlg;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -603,12 +604,13 @@ public class Contents {
 	}
 
 	/**
-	 * Caclulates an MD5 hash for each file in the archive.
-	 * @return the MD5 hashes
+	 * Caclulates a hash for each file in the archive.
+	 * @param alg hash algorithm
+	 * @return the hashes
 	 * @throws NoSuchAlgorithmException if the algorithm isn't supported
 	 * @throws IOException there was an IO error
 	 */
-	public String[] getFileChecksums() throws NoSuchAlgorithmException, IOException {
+	public String[] getFileChecksums(FileDigestsAlg alg) throws NoSuchAlgorithmException, IOException {
 		/**
 		 * This could be more efficiently handled during the output phase using a filtering channel,
 		 * but would require placeholder values in the archive and some state. This is left for a
@@ -623,14 +625,14 @@ public class Contents {
 			if ( object instanceof File) {
 				FileInputStream fileInput = new FileInputStream(( File) object);
 				final ReadableChannelWrapper input = new ReadableChannelWrapper( fileInput.getChannel());
-				final Key< byte[]> key = input.start( "SHA-256");
+				final Key< byte[]> key = input.start( alg.getAlgName());
 				while ( input.read( buffer) != -1) buffer.rewind();
 				value = Util.hex(input.finish(key));
 				input.close();
 				fileInput.close();
 			} else if ( object instanceof URL) {
 				final ReadableChannelWrapper input = new ReadableChannelWrapper( Channels.newChannel((( URL) object).openConnection().getInputStream()));
-				final Key< byte[]> key = input.start( "SHA-256");
+				final Key< byte[]> key = input.start( alg.getAlgName());
 				while ( input.read( buffer) != -1) buffer.rewind();
 				value = Util.hex(input.finish(key));
 				input.close();


### PR DESCRIPTION
It was needed for old systems, which ignores RPMTAG_FILEDIGESTALGO and always uses MD5