### PR TITLE
Add loongarch64 as a supported platform

### DIFF
--- a/src/main/java/org/redline_rpm/header/Architecture.java
+++ b/src/main/java/org/redline_rpm/header/Architecture.java
@@ -23,5 +23,6 @@ public enum Architecture {
 	XTENSA,
 	X86_64,
 	PPC64LE,
-	AARCH64
+	AARCH64,
+	LOONGARCH64
 }


### PR DESCRIPTION
Please refer to  https://docs.kernel.org/arch/loongarch/introduction.html for an introduction to the Ioongarch64 architecture